### PR TITLE
fix: update Makefile target directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # ====================================================================================
 
 COMMANDS_SRC_DIR := $(dir $(lastword $(MAKEFILE_LIST)))commands
-COMMANDS_TARGET_DIRS := $(HOME)/.cursor/commands $(HOME)/.claude/commands $(HOME)/.codex/prompts $(HOME)/.config/opencode/command $(HOME)/.config/amp/commands $(HOME)/.kilocode/workflows $(HOME)/Documents/Cline/Rules
+COMMANDS_TARGET_DIRS := $(HOME)/.cursor/commands $(HOME)/.claude/commands $(HOME)/.codex/prompts $(HOME)/.config/opencode/command $(HOME)/.config/amp/commands $(HOME)/.kilocode/workflows $(HOME)/.cline/commands
 
 # ====================================================================================
 # COMMANDS


### PR DESCRIPTION
## Changes Made
- Fixed incorrect target directory path from .Documents/Cline/Rules to .cline/commands
- Updated Makefile to use the correct .cline/commands directory
- Maintained all other target directories for various AI tools

## Technical Details
- The Makefile was referencing an outdated path structure
- Updated to use the current .cline/commands directory format
- Ensures proper command distribution to Cline AI tool
- All other AI tool directories remain unchanged

## Testing
- Verified the corrected path exists and is properly formatted
- All pre-commit hooks pass (Biome formatting, linting)
- No breaking changes to existing functionality
- Maintains compatibility with all supported AI tools

🤖 Generated with opencode on Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the default destination for command syncs to a standardized hidden app folder in the user’s home directory, replacing the previous location under Documents. This reduces clutter and aligns with platform conventions while keeping the sync behavior unchanged.
  - Note: Existing commands in the old location will no longer be updated; check the new home directory path for synced commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->