### PR TITLE
feat: add mcp-sync target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,22 @@ MCP_SRC := $(dir $(lastword $(MAKEFILE_LIST))).ruler/mcp.json
 MCP_TARGET_DIRS := $(HOME)/.cursor $(HOME)/.claude $(HOME)/.codex
 
 # ====================================================================================
-# COMMANDS
+# ROOT TARGETS
 # ====================================================================================
+
+.PHONY: sync
+sync: ## Sync project commands and MCP configuration to assistant-specific directories.
+	@make commands-sync
+	@make mcp-sync
 
 .PHONY: prepare
 prepare: ## Prepare the project for development.
 	@make commands-copy
-	@make mcp-sync
+
+# ====================================================================================
+# COMMANDS
+# ====================================================================================
+
 
 .PHONY: commands-sync
 commands-sync: ## Sync project commands to assistant-specific directories.

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@
 COMMANDS_SRC_DIR := $(dir $(lastword $(MAKEFILE_LIST)))commands
 COMMANDS_TARGET_DIRS := $(HOME)/.cursor/commands $(HOME)/.claude/commands $(HOME)/.codex/prompts $(HOME)/.config/opencode/command $(HOME)/.config/amp/commands $(HOME)/.kilocode/workflows $(HOME)/Documents/Cline/Rules
 
+MCP_SRC := $(dir $(lastword $(MAKEFILE_LIST))).ruler/mcp.json
+MCP_TARGET_DIRS := $(HOME)/.cursor $(HOME)/.claude $(HOME)/.codex
+
 # ====================================================================================
 # COMMANDS
 # ====================================================================================
@@ -14,6 +17,7 @@ COMMANDS_TARGET_DIRS := $(HOME)/.cursor/commands $(HOME)/.claude/commands $(HOME
 .PHONY: prepare
 prepare: ## Prepare the project for development.
 	@make commands-copy
+	@make mcp-sync
 
 .PHONY: commands-sync
 commands-sync: ## Sync project commands to assistant-specific directories.
@@ -29,6 +33,21 @@ commands-sync: ## Sync project commands to assistant-specific directories.
 .PHONY: commands-copy
 commands-copy: ## Copy commands to .ruler directory.
 	@cp $(COMMANDS_SRC_DIR)/*.md .ruler/
+
+.PHONY: mcp-sync
+mcp-sync: ## Sync MCP configuration from .ruler/mcp.json to CLI tools.
+	@if [ ! -f $(MCP_SRC) ]; then \
+		echo "Error: $(MCP_SRC) not found"; \
+		exit 1; \
+	fi
+	@for target in $(MCP_TARGET_DIRS); do \
+		if mkdir -p $$target && cp $(MCP_SRC) $$target/mcp.json; then \
+			echo "Synced $(MCP_SRC) → $$target/mcp.json"; \
+		else \
+			echo "Failed syncing $(MCP_SRC) → $$target/mcp.json"; \
+			exit 1; \
+		fi; \
+	done
 
 # ====================================================================================
 # HELP


### PR DESCRIPTION
## Changes Made
- Added `mcp-sync` target to sync MCP configurations from `.ruler/mcp.json` to CLI tools
- Added `MCP_SRC` and `MCP_TARGET_DIRS` variables to define source and target directories
- Integrated `mcp-sync` into `prepare` target for automatic syncing during project setup

## Technical Details
- Copies `.ruler/mcp.json` to `~/.cursor`, `~/.claude`, and `~/.codex` directories
- Ensures all CLI tools use the same MCP server configuration
- Fails gracefully if source file is not found

## Testing
- Manually tested `make mcp-sync` command
- Verified files are copied to target directories
- Confirmed integration with `make prepare`

## Usage
```bash
# Sync MCP configs manually
make mcp-sync

# Or as part of prepare
make prepare
```

🤖 Generated with Claude Code by Claude Sonnet 4.5
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a Makefile target mcp-sync that syncs .ruler/mcp.json to local CLI tool directories, and runs during make prepare to keep all tools on the same MCP config.

- **New Features**
  - Syncs .ruler/mcp.json to ~/.cursor, ~/.claude, and ~/.codex.
  - Adds MCP_SRC and MCP_TARGET_DIRS for configurable source/targets.
  - Fails early with a clear message if the source file is missing.

<!-- End of auto-generated description by cubic. -->

