### PR TITLE
Add grill-me and obsidian skills to mattpocock/skills

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -53,7 +53,7 @@ obra/superpowers dispatching-parallel-agents,executing-plans,finishing-a-develop
 PaulRBerg/agent-skills biome-js,bump-deps,bump-release,cli-gh,code-polish,code-review,code-simplify,effect-ts,md-docs,tailwind-css,yeet
 
 # mattpocock/skills (18 total) - keep dev workflow
-mattpocock/skills improve-codebase-architecture,prd-to-issues,prd-to-plan,qa,request-refactor-plan,tdd,triage-issue,write-a-prd
+mattpocock/skills grill-me,improve-codebase-architecture,obsidian,prd-to-issues,prd-to-plan,qa,request-refactor-plan,tdd,triage-issue,write-a-prd
 
 # max-sixty/worktrunk (1 total) - keep all
 max-sixty/worktrunk


### PR DESCRIPTION
## Summary
Updated the mattpocock/skills entry in SKILLS.txt to include two additional skills: `grill-me` and `obsidian`.

## Changes
- Added `grill-me` skill to mattpocock's skill set
- Added `obsidian` skill to mattpocock's skill set
- Skills are now listed in alphabetical order within the entry

## Details
The mattpocock/skills entry now includes 10 skills (previously 8), maintaining the "keep dev workflow" category designation. The new skills have been inserted in alphabetical order among the existing skills: improve-codebase-architecture, prd-to-issues, prd-to-plan, qa, request-refactor-plan, tdd, triage-issue, and write-a-prd.

https://claude.ai/code/session_01TareWzPezzJAUzjhy7vj8N

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored `grill-me` and `obsidian` to the `mattpocock/skills` entry in SKILLS.txt after they were dropped by selective skill filtering. Maintains alphabetical ordering of the skills.

<sup>Written for commit 4bfdc4185b690998f37c38cc2353191c586a0110. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

