### PR TITLE
Restore grill-me and obsidian-vault skills for mattpocock/skills

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -53,7 +53,7 @@ obra/superpowers dispatching-parallel-agents,executing-plans,finishing-a-develop
 PaulRBerg/agent-skills biome-js,bump-deps,bump-release,cli-gh,code-polish,code-review,code-simplify,effect-ts,md-docs,tailwind-css,yeet
 
 # mattpocock/skills (18 total) - keep dev workflow
-mattpocock/skills grill-me,improve-codebase-architecture,obsidian,prd-to-issues,prd-to-plan,qa,request-refactor-plan,tdd,triage-issue,write-a-prd
+mattpocock/skills grill-me,improve-codebase-architecture,obsidian-vault,prd-to-issues,prd-to-plan,qa,request-refactor-plan,tdd,triage-issue,write-a-prd
 
 # max-sixty/worktrunk (1 total) - keep all
 max-sixty/worktrunk

--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -53,7 +53,7 @@ obra/superpowers dispatching-parallel-agents,executing-plans,finishing-a-develop
 PaulRBerg/agent-skills biome-js,bump-deps,bump-release,cli-gh,code-polish,code-review,code-simplify,effect-ts,md-docs,tailwind-css,yeet
 
 # mattpocock/skills (18 total) - keep dev workflow
-mattpocock/skills improve-codebase-architecture,prd-to-issues,prd-to-plan,qa,request-refactor-plan,tdd,triage-issue,write-a-prd
+mattpocock/skills grill-me,improve-codebase-architecture,obsidian,prd-to-issues,prd-to-plan,qa,request-refactor-plan,tdd,triage-issue,write-a-prd
 
 # max-sixty/worktrunk (1 total) - keep all
 max-sixty/worktrunk


### PR DESCRIPTION
## Summary
- Restore `grill-me` and `obsidian-vault` skills to mattpocock/skills entry in SKILLS.txt
- These were dropped during the selective skill installation filtering in #107
- Fixes the skill name to `obsidian-vault` (not `obsidian`)

## Test plan
- [ ] Verify SKILLS.txt has `grill-me` and `obsidian-vault` in the mattpocock/skills line

https://claude.ai/code/session_01TareWzPezzJAUzjhy7vj8N