### PR TITLE
fix: incremental skills-install on SKILLS.txt changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,13 +202,7 @@ skills-install: ## Ensure skills from SKILLS.txt are installed and reconcile man
 		printf '%s|%s\n' "$$repo" "$$normalized_skills" >> "$$tmp_spec"; \
 	done < "$(SKILLS_FILE)"; \
 	if [ "$${DOTAGENTS_FORCE_SKILLS_INSTALL:-0}" = "1" ]; then \
-		spec_changed=1; \
 		echo "Forcing managed external skill reinstall..."; \
-	elif [ ! -f "$$spec_state" ] || ! cmp -s "$$tmp_spec" "$$spec_state"; then \
-		spec_changed=1; \
-		echo "Detected SKILLS.txt changes; refreshing managed external skills..."; \
-	fi; \
-	if [ "$$spec_changed" = "1" ]; then \
 		$(MAKE) skills-managed-clean; \
 		mkdir -p "$$state_dir" "$$manifest_dir" "$$external_source"; \
 		while IFS='|' read -r repo normalized_skills || [ -n "$$repo$$normalized_skills" ]; do \
@@ -216,23 +210,44 @@ skills-install: ## Ensure skills from SKILLS.txt are installed and reconcile man
 			install_repo "$$repo" "$$normalized_skills" "$$manifest_file" 0; \
 		done < "$$tmp_spec"; \
 	else \
+		if [ -f "$$spec_state" ] && ! cmp -s "$$tmp_spec" "$$spec_state"; then \
+			echo "Detected SKILLS.txt changes; applying incremental update..."; \
+			while IFS='|' read -r old_repo old_skills || [ -n "$$old_repo$$old_skills" ]; do \
+				if ! grep -qF "$$old_repo|" "$$tmp_spec"; then \
+					echo "Removing $$old_repo (deleted from SKILLS.txt)..."; \
+					manifest_file="$$manifest_dir/$$(printf '%s' "$$old_repo" | sed 's#[^A-Za-z0-9_.-]#_#g').skills"; \
+					remove_repo_skills "$$manifest_file"; \
+					rm -f "$$manifest_file"; \
+				fi; \
+			done < "$$spec_state"; \
+		fi; \
 		while IFS='|' read -r repo normalized_skills || [ -n "$$repo$$normalized_skills" ]; do \
 			manifest_file="$$manifest_dir/$$(printf '%s' "$$repo" | sed 's#[^A-Za-z0-9_.-]#_#g').skills"; \
 			reinstall_repo=0; \
-			if [ ! -f "$$manifest_file" ] || [ ! -s "$$manifest_file" ]; then \
-				reinstall_repo=1; \
-				echo "Reinstalling $$repo (missing or empty manifest)"; \
-			else \
-				while IFS= read -r skill || [ -n "$$skill" ]; do \
-					if [ -z "$$skill" ]; then \
-						continue; \
-					fi; \
-					if [ ! -e "$$external_source/$$skill" ] && [ ! -L "$$external_source/$$skill" ]; then \
-						reinstall_repo=1; \
-						echo "Reinstalling $$repo (missing $$external_source/$$skill)"; \
-						break; \
-					fi; \
-				done < "$$manifest_file"; \
+			if [ -f "$$spec_state" ]; then \
+				old_line=$$(grep "^$$repo|" "$$spec_state" 2>/dev/null || true); \
+				new_line="$$repo|$$normalized_skills"; \
+				if [ -n "$$old_line" ] && [ "$$old_line" != "$$new_line" ]; then \
+					reinstall_repo=1; \
+					echo "Reinstalling $$repo (skills selection changed)"; \
+				fi; \
+			fi; \
+			if [ "$$reinstall_repo" = "0" ]; then \
+				if [ ! -f "$$manifest_file" ] || [ ! -s "$$manifest_file" ]; then \
+					reinstall_repo=1; \
+					echo "Reinstalling $$repo (missing or empty manifest)"; \
+				else \
+					while IFS= read -r skill || [ -n "$$skill" ]; do \
+						if [ -z "$$skill" ]; then \
+							continue; \
+						fi; \
+						if [ ! -e "$$external_source/$$skill" ] && [ ! -L "$$external_source/$$skill" ]; then \
+							reinstall_repo=1; \
+							echo "Reinstalling $$repo (missing $$external_source/$$skill)"; \
+							break; \
+						fi; \
+					done < "$$manifest_file"; \
+				fi; \
 			fi; \
 			if [ "$$reinstall_repo" = "1" ]; then \
 				install_repo "$$repo" "$$normalized_skills" "$$manifest_file" 1; \


### PR DESCRIPTION
## Summary
- Replace nuke-and-reinstall-all behavior when SKILLS.txt changes with incremental diff
- Removed repos: clean only their skills + delete manifest
- Changed repos: reinstall just that repo
- New repos: install only the new one
- Unchanged repos: skip entirely
- Force reinstall still available via `DOTAGENTS_FORCE_SKILLS_INSTALL=1`

## Test plan
- [x] Added fake repo to SKILLS.txt, ran `make skills-install` - only missing/changed repos reinstalled, rest skipped
- [x] `NousResearch/hermes-agent` (empty manifest) correctly detected and retried
- [x] `getsentry/skills` (missing skill) correctly detected and reinstalled
- [x] All other repos skipped with "installed state matches SKILLS.txt"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `skills-install` to apply incremental updates when `SKILLS.txt` changes instead of reinstalling everything. This makes installs faster and avoids unnecessary work.

- **Refactors**
  - Remove deleted repos by cleaning their skills and deleting the manifest.
  - Reinstall a repo only if its skill set changed, its manifest is missing/empty, or an expected skill file/symlink is missing.
  - Install new repos; skip repos whose installed state matches `SKILLS.txt`.
  - Keep full reinstall override via `DOTAGENTS_FORCE_SKILLS_INSTALL=1`.

<sup>Written for commit d968fe0c786cd811ef88c2f65a380694774b689b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

