### PR TITLE
Update getsentry/skills and NousResearch/hermes-agent entries

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -35,7 +35,7 @@ Dicklesworthstone/coding_agent_session_search
 garrytan/gstack
 
 # getsentry/skills (24 total) - keep dev workflow skills
-getsentry/skills agents-md,claude-settings-audit,code-review,code-simplifier,commit,create-branch,create-pr,find-bugs,gh-review-requests,gha-security-review,iterate-pr,pr-writer,security-review
+getsentry/skills agents-md,claude-settings-audit,code-review,code-simplifier,commit,create-branch,find-bugs,gh-review-requests,gha-security-review,iterate-pr,pr-writer,security-review
 
 # github/awesome-copilot (257 total) - keep essential dev/infra skills
 github/awesome-copilot chrome-devtools,conventional-commit,create-implementation-plan,create-readme,create-specification,dependabot,doublecheck,editorconfig,eval-driven-dev,git-commit,github-issues,make-repo-contribution,multi-stage-dockerfile,my-issues,my-pull-requests,playwright-generate-test,prd,pytest-coverage,refactor,refactor-plan,secret-scanning,security-review,typescript-mcp-server-generator,update-implementation-plan,webapp-testing
@@ -68,7 +68,7 @@ max-sixty/worktrunk
 Merit-Systems/agentcash-skills agentcash,web-research
 
 # NousResearch/hermes-agent (creative) - keep manim-video
-NousResearch/hermes-agent manim-video
+NousResearch/hermes-agent dogfood
 
 # nextlevelbuilder/ui-ux-pro-max-skill (7 total) - keep design only
 nextlevelbuilder/ui-ux-pro-max-skill ui-ux-pro-max


### PR DESCRIPTION
Revise the entries for getsentry/skills and NousResearch/hermes-agent to reflect the latest updates in the skill sets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated SKILLS.txt to reflect current skill sets: removed `create-pr` from `getsentry/skills`, and switched `NousResearch/hermes-agent` from `manim-video` to `dogfood`.

<sup>Written for commit 19ce0c1566b8cc0e524639f0574773346579e23f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

