### PR TITLE
feat: add MemPalace MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -439,6 +439,8 @@ opencode.json
 /.clinerules.bak
 /.codex/config.json
 /.codex/config.json.bak
+/.codex/config.toml
+/.codex/config.toml.bak
 /.crush.json
 /.crush.json.bak
 /.cursor/mcp.json
@@ -457,6 +459,8 @@ opencode.json
 /.idx/mcp.json.bak
 /.junie/guidelines.md
 /.junie/guidelines.md.bak
+/.junie/mcp/mcp.json
+/.junie/mcp/mcp.json.bak
 /.kilocode/mcp.json
 /.kilocode/mcp.json.bak
 /.kilocode/rules/ruler_kilocode_instructions.md

--- a/.ruler/mcp.json
+++ b/.ruler/mcp.json
@@ -1,29 +1,33 @@
 {
   "mcpServers": {
-    "XcodeBuildMCP": {
-      "command": "xcodebuildmcp",
-      "args": ["mcp"]
-    },
-    "Serena": {
-      "command": "serena",
-      "args": ["start-mcp-server"]
-    },
-    "GitHub": {
-      "command": "sh",
-      "args": ["-c", "exec mcp-remote 'https://api.githubcopilot.com/mcp/' --header \"Authorization:Bearer $(gh auth token)\""]
+    "ChromeDevtools": {
+      "command": "chrome-devtools-mcp",
+      "args": ["--autoConnect", "--channel=beta"]
     },
     "Codex": {
       "type": "stdio",
       "command": "codex",
       "args": ["mcp-server"]
     },
-    "ChromeDevtools": {
-      "command": "chrome-devtools-mcp",
-      "args": ["--autoConnect", "--channel=beta"]
-    },
     "Context7": {
       "command": "context7-mcp",
       "args": []
+    },
+    "GitHub": {
+      "command": "sh",
+      "args": ["-c", "exec mcp-remote 'https://api.githubcopilot.com/mcp/' --header \"Authorization:Bearer $(gh auth token)\""]
+    },
+    "MemPalace": {
+      "command": "python3-mempalace",
+      "args": ["-m", "mempalace.mcp_server"]
+    },
+    "Serena": {
+      "command": "serena",
+      "args": ["start-mcp-server"]
+    },
+    "XcodeBuildMCP": {
+      "command": "xcodebuildmcp",
+      "args": ["mcp"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add MemPalace MCP server (`python3-mempalace -m mempalace.mcp_server`) for session memory auto-save
- Alphabetize all MCP server entries in `.ruler/mcp.json`

## Test plan
- [ ] Verify `python3-mempalace -m mempalace.mcp_server` starts without errors
- [ ] Verify mempalace tools (diary_write, add_drawer, kg_add) appear in Claude Code MCP tools
- [ ] Verify ruler apply produces no drift

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `MemPalace` MCP server for session memory auto-save and expose tools (`diary_write`, `add_drawer`, `kg_add`). Also alphabetize `mcpServers` in `.ruler/mcp.json` and ignore new Codex/Junie configs in `.gitignore`.

- **Migration**
  - Start the server with `python3-mempalace -m mempalace.mcp_server` to load the tools.

<sup>Written for commit 7d63b30fe95fdb8dd23369b0eb126e589f91def6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

