### PR TITLE
Add coinbase/agentic-wallet-skills to SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -25,6 +25,9 @@ blader/humanizer
 # cloudflare/skills (9 total) - keep all
 cloudflare/skills
 
+# coinbase/agentic-wallet-skills (8 total) - keep all
+coinbase/agentic-wallet-skills
+
 # coreyhaines31/marketingskills (34 total) - keep analytics only
 coreyhaines31/marketingskills analytics-tracking
 


### PR DESCRIPTION
## Summary
- Adds the `coinbase/agentic-wallet-skills` repo to `SKILLS.txt` (all 8 skills kept).
- Skills enable agents to authenticate, fund, send USDC, trade, and interact with x402 paid services on Base.

## Test plan
- [ ] Verify entry placement in `SKILLS.txt` is consistent with existing ordering.
- [ ] Confirm skill hydration picks up the new repo.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `coinbase/agentic-wallet-skills` to `SKILLS.txt`, keeping all 8 skills. This enables agents to authenticate, fund, send USDC, trade, and access x402 paid services on Base.

<sup>Written for commit 6bbb12dc061b5e6ad06879897e5d1d72d81182db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

