### PR TITLE
Add Leonxlnx/taste-skill to SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -55,6 +55,9 @@ juxt/allium
 # kunchenguid/axi (1 total) - keep all
 kunchenguid/axi
 
+# Leonxlnx/taste-skill (8 total) - keep frontend design skills, skip gpt/stitch/brutalist
+Leonxlnx/taste-skill design-taste-frontend,high-end-visual-design,minimalist-ui,redesign-existing-projects,full-output-enforcement
+
 # obra/superpowers (14 total) - keep dev workflow
 obra/superpowers dispatching-parallel-agents,executing-plans,finishing-a-development-branch,receiving-code-review,requesting-code-review,systematic-debugging,test-driven-development,using-git-worktrees,verification-before-completion,writing-plans,writing-skills
 


### PR DESCRIPTION
## Summary

Add `Leonxlnx/taste-skill` (https://github.com/Leonxlnx/taste-skill) to `SKILLS.txt`, selecting the 5 relevant frontend design skills and skipping 3 less relevant ones.

**Kept (5):**
- `design-taste-frontend` - default all-rounder for premium frontend output
- `high-end-visual-design` - agency-level fonts/spacing/shadows/animations
- `minimalist-ui` - clean editorial (Notion/Linear) style
- `redesign-existing-projects` - audit & upgrade existing sites/apps
- `full-output-enforcement` - blocks placeholders, enforces complete output

**Skipped (3):**
- `gpt-taste` - GPT/Codex-specific (we use Claude)
- `industrial-brutalist-ui` - beta, niche visual style
- `stitch-design-taste` - Google Stitch-specific

## Test plan

- [x] `bunx skills add Leonxlnx/taste-skill --global --yes --skill ...` installs all 5 skills successfully
- [x] Skills appear under `~/.agents/skills/` and symlinked to Claude Code
- [ ] `make skills-install` picks up the new entry on next sync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Leonxlnx/taste-skill` to `SKILLS.txt` to enable five frontend design skills: `design-taste-frontend`, `high-end-visual-design`, `minimalist-ui`, `redesign-existing-projects`, `full-output-enforcement`. Skip GPT/Stitch-specific and niche brutalist skills not relevant to our stack.

<sup>Written for commit 668dc46cc599d38537bb55499117548a45f594e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

