### PR TITLE
Add cursor/plugins cursor-team-kit skills to SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -34,6 +34,9 @@ coinbase/agentic-wallet-skills
 # coreyhaines31/marketingskills (34 total) - keep analytics only
 coreyhaines31/marketingskills analytics-tracking
 
+# cursor/plugins (cursor-team-kit/skills, 18 total) - keep all
+cursor/plugins check-compiler-errors,control-cli,control-ui,deslop,fix-ci,fix-merge-conflicts,get-pr-comments,loop-on-ci,make-pr-easy-to-review,new-branch-and-pr,pr-review-canvas,review-and-ship,run-smoke-tests,thermo-nuclear-code-quality-review,verify-this,weekly-review,what-did-i-get-done,workflow-from-chats
+
 # Dicklesworthstone/coding_agent_session_search (1 total) - keep all
 Dicklesworthstone/coding_agent_session_search
 


### PR DESCRIPTION
## Summary
- Adds all 18 skills from `cursor/plugins` `cursor-team-kit/skills` to `SKILLS.txt`:
  check-compiler-errors, control-cli, control-ui, deslop, fix-ci, fix-merge-conflicts, get-pr-comments, loop-on-ci, make-pr-easy-to-review, new-branch-and-pr, pr-review-canvas, review-and-ship, run-smoke-tests, thermo-nuclear-code-quality-review, verify-this, weekly-review, what-did-i-get-done, workflow-from-chats
- Source: https://github.com/cursor/plugins/tree/3347cbab5b54136f6fba0994c3a01a56f7fb7fca/cursor-team-kit/skills

## Test plan
- [ ] Run `make skills-install` and confirm `bunx skills add cursor/plugins` resolves the listed skills

https://claude.ai/code/session_012ZpGFXSPLnKCm8EiDzCNuk

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZpGFXSPLnKCm8EiDzCNuk)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added all 18 `cursor-team-kit/skills` from `cursor/plugins` to `SKILLS.txt` for managed installation. This makes the team kit skills available through our skills install flow.

- **Migration**
  - Run `make skills-install` to fetch the new `cursor/plugins` skills.

<sup>Written for commit a37be2240cb1f11766b3cf6a80f6497f77eaa11e. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/139?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

