### PR TITLE
Install openclaw/agent-skills autoreview skill

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -67,6 +67,9 @@ kunchenguid/axi
 # obra/superpowers (14 total) - keep dev workflow
 obra/superpowers dispatching-parallel-agents,executing-plans,finishing-a-development-branch,receiving-code-review,requesting-code-review,systematic-debugging,test-driven-development,using-git-worktrees,verification-before-completion,writing-plans,writing-skills
 
+# openclaw/agent-skills - keep autoreview
+openclaw/agent-skills autoreview
+
 # PaulRBerg/agent-skills (23 total) - keep dev tools
 PaulRBerg/agent-skills biome-js,bump-deps,bump-release,cli-gh,code-polish,code-review,code-simplify,effect-ts,md-docs,tailwind-css,yeet
 


### PR DESCRIPTION
## Summary

Adds `openclaw/agent-skills autoreview` to `SKILLS.txt` so the autoreview skill (referenced from https://github.com/openclaw/agent-skills/blob/main/skills/autoreview/SKILL.md) is pulled in by `make skills-install` and synced out by `make sync`.

## Test plan

- [ ] `make skills-install` clones `openclaw/agent-skills` and stages only the `autoreview` skill
- [ ] `make skills-sync` copies it into the target skill directories


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fuh2hdntRBBXkcnEaoNGiz)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the `autoreview` skill from `openclaw/agent-skills` to `SKILLS.txt` so it installs via `make skills-install` and syncs via `make skills-sync`. This pulls in only the `autoreview` skill to enable automated PR reviews.

<sup>Written for commit c928b410d01f376fdb2b39efdb83a5971d4f0a83. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/141?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

