### PR TITLE
Add anthropics/defending-code-reference-harness security skills

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -10,6 +10,9 @@ antfu/skills antfu,pnpm,slidev,tsdown,turborepo,vite,vitest
 # anthropics/claude-plugins-official (19 total) - keep Claude/MCP dev skills
 anthropics/claude-plugins-official claude-automation-recommender,claude-md-improver,frontend-design,writing-hookify-rules,build-mcp-app,build-mcp-server,build-mcpb,playground,agent-development,command-development,hook-development,mcp-integration,plugin-settings,plugin-structure,skill-development,skill-creator
 
+# anthropics/defending-code-reference-harness (6 total) - keep all security skills
+anthropics/defending-code-reference-harness customize,patch,quickstart,threat-model,triage,vuln-scan
+
 # anthropics/knowledge-work-plugins (114 total) - keep dev/planning/search
 anthropics/knowledge-work-plugins memory-management,start,task-management,update,knowledge-synthesis,search,search-strategy,source-management,architecture,code-review,debug,deploy-checklist,documentation,incident-response,standup,system-design,tech-debt,testing-strategy,analyze,build-dashboard,create-viz,data-visualization,explore-data,view-pdf
 


### PR DESCRIPTION
## Summary

Adds the [`anthropics/defending-code-reference-harness`](https://github.com/anthropics/defending-code-reference-harness) skills to `SKILLS.txt`.

This repo provides skills for threat modeling, scanning, triage, and patching, plus an autonomous scanning harness. The 6 skills (under `.claude/skills/`) are:

- `customize` — port the pipeline to custom targets (language, detector, vuln class)
- `patch` — generate and validate fixes
- `quickstart` — 30-second intro and guided first run
- `threat-model` — build and manage threat models
- `triage` — verify, deduplicate, and rank findings
- `vuln-scan` — run static vulnerability scans

The entry is placed in alphabetical order among the other `anthropics/*` repos.

> Note: the request mentioned `SKILLs.md`, but the actual file in the repo is `SKILLS.txt`, so the entry was added there.

https://claude.ai/code/session_01R3SPBNgGdzJ2kgMrLsTAd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3SPBNgGdzJ2kgMrLsTAd3)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds security skills from `anthropics/defending-code-reference-harness` to `SKILLS.txt` to enable threat modeling, static scanning, triage, and patching workflows. Includes six skills (`customize`, `patch`, `quickstart`, `threat-model`, `triage`, `vuln-scan`) and places the entry in alphabetical order with other `anthropics/*` repos.

<sup>Written for commit 897e44e3860892714ebfce4f64ef819f472fd2be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

