### PR TITLE
Add jasonswett/llm-skills to SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -58,6 +58,9 @@ googleworkspace/cli gws-calendar,gws-calendar-agenda,gws-calendar-insert,gws-doc
 # inference-sh/skills (78 total) - keep core tools
 inference-sh/skills web-search,web-research,ai-sdk,agent-browser,agent-ui
 
+# jasonswett/llm-skills (5 total) - keep all
+jasonswett/llm-skills
+
 # juxt/allium - keep all
 juxt/allium
 


### PR DESCRIPTION
## Summary
Adds [`jasonswett/llm-skills`](https://github.com/jasonswett/llm-skills) to `SKILLS.txt`.

This is a collection of shared skills for AI coding assistants (Claude Code, Codex, etc.) with 5 dev/testing workflow skills — `performance-optimize`, `rename-model`, `software-design-review`, `tdd`, `test-design-review` — all kept.

The entry is inserted alphabetically by owner (between `inference-sh/skills` and `juxt/allium`) and follows the file's existing `# owner/repo (N total) - keep all` comment convention.

## Changes
- `SKILLS.txt`: added the `jasonswett/llm-skills` entry (install all skills)

https://claude.ai/code/session_01NQzAFfb5WkGaMVwosUmHeG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQzAFfb5WkGaMVwosUmHeG)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `jasonswett/llm-skills` to `SKILLS.txt`, keeping all five skills.
The entry is inserted alphabetically and follows the file’s comment convention.

<sup>Written for commit fff32ea6a5f899bc48cfcbb30ff16edbd1e30502. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

