### PR TITLE
Add google/skills to SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -52,6 +52,9 @@ getsentry/skills agents-md,claude-settings-audit,code-review,code-simplifier,com
 # github/awesome-copilot (257 total) - keep essential dev/infra skills
 github/awesome-copilot chrome-devtools,conventional-commit,create-implementation-plan,create-readme,create-specification,dependabot,doublecheck,editorconfig,eval-driven-dev,git-commit,github-issues,make-repo-contribution,multi-stage-dockerfile,my-issues,my-pull-requests,playwright-generate-test,prd,pytest-coverage,refactor,refactor-plan,secret-scanning,security-review,typescript-mcp-server-generator,update-implementation-plan,webapp-testing
 
+# google/skills (30 total) - keep all
+google/skills
+
 # googleworkspace/cli (93 total) - keep core gmail/calendar/drive
 googleworkspace/cli gws-calendar,gws-calendar-agenda,gws-calendar-insert,gws-docs,gws-docs-write,gws-drive,gws-drive-upload,gws-gmail,gws-gmail-read,gws-gmail-send,gws-sheets,gws-sheets-read,gws-tasks
 


### PR DESCRIPTION
## Summary

Adds [`google/skills`](https://github.com/google/skills) — Google's official Agent Skills repository — to `SKILLS.txt`.

The shared link (`https://t.co/OPbuqKzmFx`) resolves to `https://github.com/google/skills`.

## Details

- The repo contains **30 skills**, all under `skills/cloud/`, installable via `bunx skills add google/skills`.
- Coverage: Gemini APIs (`gemini-api`, `gemini-agents-api`, `gemini-interactions-api`), Agent Platform (deploy, inference, tuning, model/prompt/endpoint/RAG-engine/skill registry management, eval flywheel, migrate-from-ai-studio), core GCP services (`bigquery-basics`, `alloydb-basics`, `cloud-run-basics`, `cloud-sql-basics`, `firebase-basics`, `gke-basics`, `gcloud`), recipes (auth, onboarding, networking-observability), and Well-Architected Framework modules (security, reliability, cost/performance optimization, operational excellence, sustainability).
- Added as **keep all** since it's a focused, official, coherent skill set — matching the convention used for similar repos (e.g. `addyosmani/agent-skills`).
- Placed alphabetically between `github/awesome-copilot` and `googleworkspace/cli`.

```
# google/skills (30 total) - keep all
google/skills
```

https://claude.ai/code/session_01CXsecBGWkKsN2kwaq7sqFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXsecBGWkKsN2kwaq7sqFA)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `google/skills` — Google’s official Agent Skills repository — to SKILLS.txt, keeping all 30 skills. Placed alphabetically between `github/awesome-copilot` and `googleworkspace/cli`.

<sup>Written for commit 28ecd4bf9f9aa0d17b90a1a3492bf08f84db96ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

