### PR TITLE
Add index.how/to/articulate to SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -58,6 +58,9 @@ github/awesome-copilot chrome-devtools,conventional-commit,create-implementation
 # googleworkspace/cli (93 total) - keep core gmail/calendar/drive
 googleworkspace/cli gws-calendar,gws-calendar-agenda,gws-calendar-insert,gws-docs,gws-docs-write,gws-drive,gws-drive-upload,gws-gmail,gws-gmail-read,gws-gmail-send,gws-sheets,gws-sheets-read,gws-tasks
 
+# index.how/to/articulate - keep all
+https://index.how/to/articulate
+
 # inference-sh/skills (78 total) - keep core tools
 inference-sh/skills web-search,web-research,ai-sdk,agent-browser,agent-ui
 


### PR DESCRIPTION
## Summary

Adds `https://index.how/to/articulate` as a skill source in `SKILLS.txt`.

The first token of each `SKILLS.txt` line is passed directly to `bunx skills add`, which accepts URLs in addition to `owner/repo` slugs. The entry is placed in alphabetical position among the "i" entries (before `inference-sh/skills`).

## Changes

- Added `https://index.how/to/articulate` entry to `SKILLS.txt` with a descriptive comment.

https://claude.ai/code/session_01EfcgKjFt4TQPAeH5sxNJRh

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfcgKjFt4TQPAeH5sxNJRh)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added https://index.how/to/articulate as a URL skill source in SKILLS.txt so `bunx skills add` can install it. Placed alphabetically among the “i” entries and marked to keep all.

<sup>Written for commit eac31ad35bf6d08d3a5f42e823434de408d53a72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

