### PR TITLE
Update SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -91,8 +91,8 @@ openclaw/agent-skills autoreview
 # PaulRBerg/agent-skills (23 total) - keep dev tools
 PaulRBerg/agent-skills biome-js,bump-deps,bump-release,cli-gh,code-polish,code-review,code-simplify,effect-ts,md-docs,tailwind-css,yeet
 
-# mattpocock/skills (18 total) - keep core workflow
-mattpocock/skills diagnose,grill-me,grill-with-docs,improve-codebase-architecture,obsidian-vault,prd-to-issues,prd-to-plan,qa,request-refactor-plan,tdd,to-issues,to-prd,triage-issue,write-a-prd,write-a-skill
+# mattpocock/skills (19 total) - keep core workflow
+mattpocock/skills diagnose,grill-me,grill-with-docs,improve-codebase-architecture,obsidian-vault,prd-to-issues,prd-to-plan,qa,request-refactor-plan,tdd,teach,to-issues,to-prd,triage-issue,write-a-prd,write-a-skill
 
 # max-sixty/worktrunk (1 total) - keep all
 max-sixty/worktrunk


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the missing teach skill to `mattpocock/skills` and updated the total from 18 to 19 to reflect the current set.
This keeps the core workflow list accurate.

<sup>Written for commit 0e08e0a53896a1ef6e4fd60e744efacb64bceaa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

