### PR TITLE
Add elvisun/newsjack to SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -49,6 +49,9 @@ Dicklesworthstone/coding_agent_session_search
 # donnfelker/donnfelker-plugin-marketplace (7 total) - keep all
 donnfelker/donnfelker-plugin-marketplace
 
+# elvisun/newsjack (19 total) - keep all
+elvisun/newsjack
+
 # emilkowalski/skill (1 total) - keep all
 emilkowalski/skill
 


### PR DESCRIPTION
Adds [elvisun/newsjack](https://github.com/elvisun/newsjack) to `SKILLS.txt`.

newsjack is an open-source collection of agent skills that turn an agent into a full PR team (media monitoring, pitch development, journalist research, PR strategy). The repo contains 19 skills, all of which are installed (no skill filter specified).

Inserted in alphabetical order between `donnfelker` and `emilkowalski`.

https://claude.ai/code/session_01Pd3DdGA4syzyAbrtRvywVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pd3DdGA4syzyAbrtRvywVX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `elvisun/newsjack` to `SKILLS.txt`, enabling all 19 PR-focused agent skills (media monitoring, pitching, journalist research, strategy).
Inserted in alphabetical order between `donnfelker` and `emilkowalski`.

<sup>Written for commit 2865a10db4de3a332eb9a030657d85c9e41a4bc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

