### PR TITLE
fix(ruler): pin ruler to 0.3.42 to avoid 0.3.43 schema break

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ DOTDIRS_SRC_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 SKILLS_FILE := $(dir $(lastword $(MAKEFILE_LIST)))SKILLS.txt
 
+# Pin Ruler: 0.3.43 dropped the [global] config section and broke aider MCP merge.
+RULER_VERSION := 0.3.42
+
 # ====================================================================================
 # ROOT TARGETS
 # ====================================================================================
@@ -338,7 +341,7 @@ ruler-apply-global: ruler-prepare ## Apply Ruler outputs to global paths.
 		ruler_src="$(abspath $(dir $(lastword $(MAKEFILE_LIST))))/.ruler"; \
 		ruler_home="$$HOME/.ruler"; \
 		rsync -a --delete "$$ruler_src/" "$$ruler_home/"; \
-		bunx @intellectronica/ruler apply --project-root "$$HOME" --config "$$ruler_home/ruler.toml" --local-only'
+		bunx @intellectronica/ruler@$(RULER_VERSION) apply --project-root "$$HOME" --config "$$ruler_home/ruler.toml" --local-only'
 
 .PHONY: ruler-dotdirs-sync
 ruler-dotdirs-sync: ## Sync repo dot directories to $HOME equivalents.


### PR DESCRIPTION
## Problem

`ruler-apply-global` calls `bunx @intellectronica/ruler` without a version pin, so it always resolves the latest release. Ruler `0.3.43` (published 2026-06-20) introduced two breaking changes:

1. Dropped the `[global]` config section — the strict schema now rejects `ruler.toml`:
   ```
   [ruler] Invalid configuration file format (Context: File: ~/.ruler/ruler.toml, Errors: global)
   ```
2. Broke aider MCP merge (parses the generated YAML `.aider.conf.yml` as JSON → exit 1).

This broke the dotfiles `Upgrade` workflow (which runs `make -C dotagents sync`).

## Fix

Pin to the last known-good version `0.3.42` via a `RULER_VERSION` variable.

Validated locally: `0.3.42` + current config = exit 0, no errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `@intellectronica/ruler` to 0.3.42 to avoid the 0.3.43 schema change that rejects our config and breaks aider MCP merge. Restores the dotfiles Upgrade workflow and `ruler-apply-global`.

- **Bug Fixes**
  - Pin in Makefile via `RULER_VERSION := 0.3.42` and call `bunx @intellectronica/ruler@$(RULER_VERSION)`.
  - Prevents 0.3.43 failures (dropped `[global]` section, `.aider.conf.yml` parse error).

<sup>Written for commit 0b92d27e8be9d50c2b7e1de2ca85c0fea0941d74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

