### PR TITLE
feat(mcp): add Sentry remote MCP server

### DIFF
--- a/.ruler/mcp.json
+++ b/.ruler/mcp.json
@@ -21,6 +21,10 @@
       "command": "python3-mempalace",
       "args": ["-m", "mempalace.mcp_server"]
     },
+    "Sentry": {
+      "command": "mcp-remote",
+      "args": ["https://mcp.sentry.dev/mcp"]
+    },
     "Serena": {
       "command": "serena",
       "args": ["start-mcp-server"]


### PR DESCRIPTION
## Summary

Adds the [Sentry remote MCP server](https://mcp.sentry.dev/mcp) to `.ruler/mcp.json` so it is distributed to all configured agents via `ruler`.

## Change

```json
"Sentry": {
  "command": "mcp-remote",
  "args": ["https://mcp.sentry.dev/mcp"]
}
```

- Bridges the remote HTTP MCP endpoint over stdio with `mcp-remote` (same approach as the existing `GitHub` entry).
- OAuth is handled interactively by `mcp-remote` on first connect, so no token header is needed.
- Inserted in alphabetical order between `MemPalace` and `Serena`.

## Follow-up

Run `make sync` / `ruler:apply` to regenerate per-agent configs after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Sentry remote MCP server to `.ruler/mcp.json` so all agents can use Sentry via `ruler`. Bridges the HTTP endpoint with `mcp-remote`; OAuth is interactive on first connect.

- **New Features**
  - Added `Sentry`: `command: "mcp-remote"`, `args: ["https://mcp.sentry.dev/mcp"]`.
  - Placed alphabetically between `MemPalace` and `Serena`.

- **Migration**
  - Run `make sync` or `ruler:apply` to update per-agent configs.

<sup>Written for commit bb33cac2ee78629b130ee6323c08369c048d3eba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

