### PR TITLE
fix: migrate ruler [global] to [mcp] and disable aider mcp

### DIFF
--- a/.ruler/ruler.toml
+++ b/.ruler/ruler.toml
@@ -44,6 +44,11 @@ enabled = true
 output_path_instructions = "ruler_aider_instructions.md"
 output_path_config = ".aider.conf.yml"
 
+# Aider's MCP config lives in the same YAML file as its instructions, which
+# Ruler writes then tries to re-parse as JSON, failing the apply. Disable it.
+[agents.aider.mcp]
+enabled = false
+
 [agents.firebase]
 enabled = true
 output_path = ".idx/airules.md"
@@ -85,8 +90,8 @@ output_path = ".goosehints"
 [agents.jules]
 enabled = true
 
-# --- Global Configuration ---
-[global]
+# --- MCP Configuration ---
+[mcp]
 # MCP merge strategy: 'merge' or 'overwrite' (default: 'merge')
 merge_strategy = "merge"
 


### PR DESCRIPTION
## Problem

The `dotfiles` `Upgrade` workflow fails at `ruler-apply-global` (`make upgrade-dev`):

```
[ruler] Invalid configuration file format (Context: File: ~/.ruler/ruler.toml, Errors: global)
make[3]: *** [Makefile:337: ruler-apply-global] Error 1
```

`@intellectronica/ruler` 0.3.41 has no `[global]` table in its config schema. Valid top-level keys are `default_agents`, `agents`, `mcp`, `gitignore`, `skills`. The `merge_strategy` setting belongs under `[mcp]`.

## Fix

1. Move `merge_strategy = "merge"` from `[global]` to `[mcp]`.
2. Disable aider MCP (`[agents.aider.mcp] enabled = false`). Once #1 lets the apply proceed, ruler crashes writing aider's MCP config: it writes `.aider.conf.yml` as YAML (the `read:` instructions list), then re-parses it as JSON and fails.

## Verification

Ran the exact Makefile invocation locally:

```
bunx @intellectronica/ruler@latest apply --project-root "$HOME" --config "$HOME/.ruler/ruler.toml" --local-only
```

Result: `Ruler apply completed successfully.` (exit 0), all 18 agents apply cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Upgrade workflow failure by aligning `@intellectronica/ruler` config with the 0.3.41 schema and disabling Aider MCP to prevent a parse crash. Ruler apply now completes successfully.

- **Bug Fixes**
  - Moved `merge_strategy = "merge"` from `[global]` to `[mcp]` (per `@intellectronica/ruler` 0.3.41).
  - Disabled Aider MCP (`[agents.aider.mcp] enabled = false`) to avoid YAML→JSON reparse failure on `.aider.conf.yml`.

<sup>Written for commit 39583cdde423d96cfcf96c1e47b06ef668c11003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

