### PR TITLE
feat(skills): add higgsfield-ai/skills

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -73,6 +73,9 @@ google/skills agent-platform-alert-configuration,agent-platform-deploy,agent-pla
 # googleworkspace/cli (93 total) - keep core gmail/calendar/drive
 googleworkspace/cli gws-calendar,gws-calendar-agenda,gws-calendar-insert,gws-docs,gws-docs-write,gws-drive,gws-drive-upload,gws-gmail,gws-gmail-read,gws-gmail-send,gws-sheets,gws-sheets-read,gws-tasks
 
+# higgsfield-ai/skills (5 total) - keep all
+higgsfield-ai/skills higgsfield-generate,higgsfield-marketplace-cards,higgsfield-product-photoshoot,higgsfield-soul-id,higgsfield-websites
+
 # index.how/to/articulate - keep all (install-all; URL endpoint currently exposes no skills)
 https://index.how/to/articulate
 


### PR DESCRIPTION
Add `higgsfield-ai/skills` to SKILLS.txt (5 skills, install all):

- higgsfield-generate
- higgsfield-marketplace-cards
- higgsfield-product-photoshoot
- higgsfield-soul-id
- higgsfield-websites

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `higgsfield-ai/skills` to SKILLS.txt and enable install for all 5 skills: `higgsfield-generate`, `higgsfield-marketplace-cards`, `higgsfield-product-photoshoot`, `higgsfield-soul-id`, `higgsfield-websites`. Makes these skills available for use.

<sup>Written for commit 4445fd31afb27f4c52291e1b9a4c94089dc70385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

