### PR TITLE
feat(skills): migrate emilkowalski/skill to renamed emilkowalski/skills

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -52,8 +52,8 @@ donnfelker/donnfelker-plugin-marketplace codebase-analyzer,find-past-conversatio
 # elvisun/newsjack (21 total) - keep all
 elvisun/newsjack angle-generator,coverage-tracker,coverage-tracker-setup,crisis-holding,fact-check,find-journalists,headline-generator,journalist-fit-check,meanest-editor,news-search,newsjack-detector,newsjack-monitor-setup,newsjack-triage,newsworthiness-check,pr-calendar,pr-strategist,press-clip,reactive-comment,relevance-coarse-filter,story-origin-check,voice-extractor
 
-# emilkowalski/skill (3 total) - keep all
-emilkowalski/skill animation-vocabulary,emil-design-eng,review-animations
+# emilkowalski/skills (5 total) - keep all (renamed from emilkowalski/skill; adds apple-design, improve-animations)
+emilkowalski/skills animation-vocabulary,apple-design,emil-design-eng,improve-animations,review-animations
 
 # Forward-Future/loop-library (2 total) - keep all
 Forward-Future/loop-library loop-library,loopy


### PR DESCRIPTION
## What

Adds [`emilkowalski/skills`](https://github.com/emilkowalski/skills) to `SKILLS.txt`.

This repo is the **rename** of the existing `emilkowalski/skill` entry — `github.com/emilkowalski/skill` now redirects to `github.com/emilkowalski/skills`. Rather than add a duplicate line (which would resolve to the same repo via the redirect and double-install the 3 overlapping skills), this updates the existing entry to the new name and picks up the two new skills the repo now ships.

## Changes

- `emilkowalski/skill` → `emilkowalski/skills` (repo renamed upstream)
- Skill count `3 total` → `5 total`, keeping all:
  - `animation-vocabulary` *(existing)*
  - `emil-design-eng` *(existing)*
  - `review-animations` *(existing)*
  - `apple-design` *(new)*
  - `improve-animations` *(new)*

## Notes

- Skill list is stored sorted; the Makefile normalizes with `LC_ALL=C sort` at install time, so ordering is cosmetic.
- No `make sync` was run here — this is a spec-only change to `SKILLS.txt`; skills are reconciled/installed on the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Y9gt32tasL1vToUnLRcFJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019Y9gt32tasL1vToUnLRcFJ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `SKILLS.txt` to replace `emilkowalski/skill` with the renamed `emilkowalski/skills`, avoiding duplicate installs via redirect and aligning with the current repo. Adds `apple-design` and `improve-animations` (keeping the existing three) for 5 total.

<sup>Written for commit e4dab4301a27233eec39bece9be53e1debb488a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

