### PR TITLE
feat(skills): add Graphify-Labs/graphify skill and prerequisites

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -73,6 +73,9 @@ google/skills agent-platform-alert-configuration,agent-platform-deploy,agent-pla
 # googleworkspace/cli (93 total) - keep core gmail/calendar/drive
 googleworkspace/cli gws-calendar,gws-calendar-agenda,gws-calendar-insert,gws-docs,gws-docs-write,gws-drive,gws-drive-upload,gws-gmail,gws-gmail-read,gws-gmail-send,gws-sheets,gws-sheets-read,gws-tasks
 
+# Graphify-Labs/graphify (1 total) - keep all
+Graphify-Labs/graphify
+
 # higgsfield-ai/skills (5 total) - keep all
 higgsfield-ai/skills higgsfield-generate,higgsfield-marketplace-cards,higgsfield-product-photoshoot,higgsfield-soul-id,higgsfield-websites
 


### PR DESCRIPTION
## Summary

- Adds `Graphify-Labs/graphify` to `SKILLS.txt` (1 skill: `graphify`, install-all)
- Adds `rules/graphify.md` with prerequisites, key commands, and `.claudeignore` setup — baked into `~/.claude/CLAUDE.md` via the ruler pipeline

## Details

**SKILLS.txt**: registers the `/graphify` skill that maps any codebase into a queryable knowledge graph using tree-sitter AST (local, no LLM for code).

**rules/graphify.md**: documents prerequisites and usage so Claude Code always knows:
- Install: `uv tool install graphifyy` (package is `graphifyy`, command is `graphify`)
- `.claudeignore` entries to prevent prompt cache invalidation
- Key commands: `/graphify .`, `query`, `path`, `explain`

## Test plan

- [ ] `cd dotagents && make sync` installs the graphify skill
- [ ] `make ruler-apply-global` bakes the rule into `~/.claude/CLAUDE.md`
- [ ] `/graphify` skill is available in Claude Code after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du5ovCuAyNjB7mJq6T7bq4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `Graphify-Labs/graphify` skill to `SKILLS.txt` so it’s included in the global skills registry. This makes the Graphify skill available during standard sync/install workflows.

<sup>Written for commit 86b81ec7c3c80ded3d9e6a7ae73fbc92ba0308eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

