### PR TITLE
feat(skills): add kitlangton/skills effect to SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -94,6 +94,9 @@ juxt/allium allium,distill,elicit,propagate,tend,weed
 # kitlangton/motel (1 total) - keep all
 kitlangton/motel motel-debug
 
+# kitlangton/skills (1 total) - keep all
+kitlangton/skills effect
+
 # kunchenguid/axi (2 total) - keep all
 kunchenguid/axi axi,no-mistakes
 


### PR DESCRIPTION
Adds [kitlangton/skills](https://github.com/kitlangton/skills) to `SKILLS.txt`, keeping its single skill:

- `effect` — Production TypeScript with Effect v4

The entry is placed alphabetically after the existing `kitlangton/motel` entry and follows the file's `repo skill1,skill2,...` format with a `(1 total) - keep all` comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEHsVQQfkVUyEc9HJ49Gcn

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEHsVQQfkVUyEc9HJ49Gcn)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `kitlangton/skills` to SKILLS.txt with the `effect` skill. Sorted alphabetically after `kitlangton/motel` using the existing repo skill format.

<sup>Written for commit 877feba2d09a8d552b591704c2d62f5fc83846d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

