### PR TITLE
feat(skills): add ogulcancelik/herdr herdr to SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -112,6 +112,9 @@ Leonxlnx/taste-skill design-taste-frontend,high-end-visual-design,minimalist-ui,
 # obra/superpowers (14 total) - keep dev workflow
 obra/superpowers dispatching-parallel-agents,executing-plans,finishing-a-development-branch,receiving-code-review,requesting-code-review,systematic-debugging,test-driven-development,using-git-worktrees,verification-before-completion,writing-plans,writing-skills
 
+# ogulcancelik/herdr (1 total) - keep all
+ogulcancelik/herdr herdr
+
 # openclaw/agent-skills - keep autoreview
 openclaw/agent-skills autoreview
 


### PR DESCRIPTION
## Summary

Adds the [`ogulcancelik/herdr`](https://github.com/ogulcancelik/herdr/blob/master/SKILL.md) skill to `SKILLS.txt`.

Herdr is a terminal multiplexer for coding agents. The `herdr` skill lets an agent inspect and control panes, tabs, workspaces, terminals, and commands, and communicate with other agents (requires `HERDR_ENV=1`).

## Details

- The repo exposes a **single** skill at the root (`SKILL.md`, `name: herdr`), so it's pinned explicitly as `ogulcancelik/herdr herdr` per the SKILLS.txt convention (same as the recent `github/gh-stack` and `blader/arbitrage` entries).
- Inserted in alphabetical position between `obra/superpowers` and `openclaw/agent-skills`.

```diff
+# ogulcancelik/herdr (1 total) - keep all
+ogulcancelik/herdr herdr
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ayjzs2vB3z4FxYgo2aS7cE)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the `ogulcancelik/herdr` `herdr` skill to `SKILLS.txt`. It lets agents control Herdr panes, tabs, workspaces, and terminals, and enables inter-agent messaging when `HERDR_ENV=1`.

<sup>Written for commit a59dfbc8803bbbc1131fe164c7de9b5819d96f1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

