### PR TITLE
feat(skills): add cursor/plugins pstack and cursor skills to SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -40,8 +40,8 @@ coinbase/agentic-wallet-skills agentic-wallet
 # coreyhaines31/marketingskills (34 total) - keep analytics only
 coreyhaines31/marketingskills analytics-tracking
 
-# cursor/plugins (cursor-team-kit/skills, 18 total) - keep all
-cursor/plugins check-compiler-errors,control-cli,control-ui,deslop,fix-ci,fix-merge-conflicts,get-pr-comments,loop-on-ci,make-pr-easy-to-review,new-branch-and-pr,pr-review-canvas,review-and-ship,run-smoke-tests,thermo-nuclear-code-quality-review,verify-this,weekly-review,what-did-i-get-done,workflow-from-chats
+# cursor/plugins (75 total) - keep cursor-team-kit + cursor SDK/plugin + pstack skills (excl. poteto-mode, benny automations)
+cursor/plugins check-compiler-errors,control-cli,control-ui,deslop,fix-ci,fix-merge-conflicts,get-pr-comments,loop-on-ci,make-pr-easy-to-review,new-branch-and-pr,pr-review-canvas,review-and-ship,run-smoke-tests,thermo-nuclear-code-quality-review,verify-this,weekly-review,what-did-i-get-done,workflow-from-chats,cli-for-agents,continual-learning,create-plugin-scaffold,review-plugin-submission,cursor-sdk,docs-canvas,orchestrate,architect,arena,automate-me,blast-radius,create-verification-skill,figure-it-out,how,interrogate,maintain-verification-skill,recall,reflect,setup-pstack,show-me-your-work,tdd,teach,typescript-best-practices,unslop,why,principle-boundary-discipline,principle-build-the-lever,principle-encode-lessons-in-structure,principle-exhaust-the-design-space,principle-experience-first,principle-fix-root-causes,principle-foundational-thinking,principle-guard-the-context-window,principle-laziness-protocol,principle-make-operations-idempotent,principle-migrate-callers-then-delete-legacy-apis,principle-minimize-reader-load,principle-model-the-domain,principle-never-block-on-the-human,principle-outcome-oriented-execution,principle-prove-it-works,principle-redesign-from-first-principles,principle-separate-before-serializing-shared-state,principle-sequence-verifiable-units,principle-subtract-before-you-add,principle-type-system-discipline
 
 # Dicklesworthstone/coding_agent_session_search (1 total) - keep all
 Dicklesworthstone/coding_agent_session_search cass


### PR DESCRIPTION
Expands the `cursor/plugins` entry in `SKILLS.txt` from 18 to 64 skills, adding the pstack skill suite and cursor SDK/plugin skills alongside the existing cursor-team-kit set.

## Added (46 new)

**pstack general (18):** architect, arena, automate-me, blast-radius, create-verification-skill, figure-it-out, how, interrogate, maintain-verification-skill, recall, reflect, setup-pstack, show-me-your-work, tdd, teach, typescript-best-practices, unslop, why

**pstack principles (21):** all `principle-*` skills

**cursor SDK/plugin (7):** cli-for-agents, continual-learning, create-plugin-scaffold, review-plugin-submission, cursor-sdk, docs-canvas, orchestrate

## Excluded

- `poteto-mode`, `check-agent-compatibility` — present in the git tree but not exposed by the `skills` CLI `--list`, so they would fail to install
- benny automations (`setup-benny`, `reproduce-and-fix-issues`, `triage-issue-reports`) — gated to a specific automation, not general-purpose
- ralph-loop / teaching / thermos plugins — out of scope (neither pstack nor cursor-core)

All 64 names validated against `bun x skills add cursor/plugins --list`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded `cursor/plugins` in `SKILLS.txt` to include pstack and Cursor SDK/plugin skills, increasing kept skills from 18 to 64. This broadens our installable skill set while avoiding non-installable or out-of-scope entries.

- **New Features**
  - Added pstack general (18) and principles (21) skills.
  - Added Cursor SDK/plugin skills (7).
  - Kept existing cursor-team-kit; excluded `poteto-mode`, `check-agent-compatibility`, benny automations, and non-core plugins.

<sup>Written for commit a093ab7b153c2045f48bda640afa4e81631c676c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

