### PR TITLE
fix: use native HTTP for Sentry MCP

### DIFF
--- a/.ruler/mcp.json
+++ b/.ruler/mcp.json
@@ -22,8 +22,8 @@
       "args": ["-m", "mempalace.mcp_server"]
     },
     "Sentry": {
-      "command": "mcp-remote",
-      "args": ["https://mcp.sentry.dev/mcp"]
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
     },
     "Serena": {
       "command": "serena",


### PR DESCRIPTION
## Summary
- Switch Sentry MCP from `mcp-remote` to native HTTP (`type: http` + `url`) in `.ruler/mcp.json`
- Avoids the broken `localhost:<ephemeral>/oauth/callback` flow when the mcp-remote listener dies mid-auth

## Test plan
- [ ] `make mcp-sync` (or `make sync`) and confirm `~/.claude/mcp.json` / `~/.cursor/mcp.json` pick up the HTTP Sentry entry
- [ ] Reconnect Sentry MCP in Cursor and confirm tools load after OAuth
- [ ] Confirm Claude Code Sentry no longer opens `localhost:15716` callbacks


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Sentry MCP to native HTTP (`type: http`, `url`) in `.ruler/mcp.json`, replacing `mcp-remote`. This removes the fragile localhost OAuth callback and fixes tool loading after auth.

- **Migration**
  - Run `make mcp-sync` to refresh local MCP config.
  - Reconnect Sentry MCP in Cursor/Claude Code.

<sup>Written for commit 33da38320a7c34db12ee84bfb70abcc21a610e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

