### PR TITLE
fix: stop stale cursor mcp.json from clobbering sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,11 @@ sync: ruler-prepare ## Sync project commands, skills, and MCP configuration to a
 	@$(MAKE) commands-sync
 	@$(MAKE) skills-install
 	@$(MAKE) skills-sync
-	@$(MAKE) mcp-sync
 	@$(MAKE) ruler-dotdirs-sync
+	# mcp-sync must run after ruler-dotdirs-sync: the latter rsyncs
+	# `.cursor/mcp.json` (and peers) into $HOME and would otherwise
+	# clobber the canonical MCP config written from `.ruler/mcp.json`.
+	@$(MAKE) mcp-sync
 endif
 
 .PHONY: ruler-prepare
@@ -319,6 +322,14 @@ mcp-sync: ## Sync MCP configuration from .ruler/mcp.json to CLI tools.
 			exit 1; \
 		fi; \
 	done
+	# Keep gitignored local mirrors aligned so a later ruler-dotdirs-sync
+	# cannot revive a stale `.cursor/mcp.json` / `.mcp.json`.
+	@root="$(abspath $(dir $(lastword $(MAKEFILE_LIST))))"; \
+	for mirror in "$$root/.cursor/mcp.json" "$$root/.mcp.json"; do \
+		mkdir -p "$$(dirname "$$mirror")"; \
+		cp $(MCP_SRC) "$$mirror"; \
+		echo "Synced $(MCP_SRC) → $$mirror"; \
+	done
 	@keys=$$(jq -c '.mcpServers | keys' $(MCP_SRC)); \
 	for settings in $(MCP_SETTINGS_TARGETS); do \
 		if [ -f "$$settings" ]; then \
@@ -350,7 +361,10 @@ ruler-dotdirs-sync: ## Sync repo dot directories to $HOME equivalents.
 			target="$$HOME/$$d"; \
 			if [ -d "$$src" ]; then \
 				mkdir -p "$$target"; \
-				rsync -a "$$src/" "$$target/"; \
+				rsync -a \
+					--exclude mcp.json \
+					--exclude mcp.json.bak \
+					"$$src/" "$$target/"; \
 				echo "Synced $$src → $$target"; \
 			fi; \
 		done'


### PR DESCRIPTION
## Summary
- Root cause of the recurring Sentry OAuth failure: `make sync` wrote the fixed MCP config, then `ruler-dotdirs-sync` rsynced a **gitignored** stale `.cursor/mcp.json` over `~/.cursor/mcp.json`, wiping native HTTP Sentry
- Run `mcp-sync` after `ruler-dotdirs-sync`
- Exclude `mcp.json` / `mcp.json.bak` from dotdir rsync
- Have `mcp-sync` refresh the local ignored mirrors so they cannot drift again

## Test plan
- [ ] `make ruler-dotdirs-sync && make mcp-sync`
- [ ] `jq .mcpServers.Sentry ~/.cursor/mcp.json` shows `{ "type": "http", "url": "https://mcp.sentry.dev/mcp" }`
- [ ] Restart Cursor MCP / reconnect Sentry and confirm tools stay available
- [ ] Run `make sync` again and confirm `~/.cursor/mcp.json` is not reverted


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a stale repo `.cursor/mcp.json` from overwriting the canonical MCP config during `make sync`, preserving the HTTP Sentry endpoint and preventing OAuth failures.

- **Bug Fixes**
  - Run `mcp-sync` after `ruler-dotdirs-sync` so the final config is correct.
  - Exclude `mcp.json` and `mcp.json.bak` from dotdir rsync.
  - Have `mcp-sync` refresh local ignored mirrors (`.cursor/mcp.json`, `.mcp.json`) to prevent drift.

<sup>Written for commit d36b2f6c86defbb5887f6b8333e60f71cc4c5cf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

