### PR TITLE
chore: fix emilkowalski/skill count in SKILLS.txt

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -49,7 +49,7 @@ Dicklesworthstone/coding_agent_session_search
 # donnfelker/donnfelker-plugin-marketplace (7 total) - keep all
 donnfelker/donnfelker-plugin-marketplace
 
-# emilkowalski/skill (1 total) - keep all
+# emilkowalski/skill (8 total) - keep all
 emilkowalski/skill
 
 # garrytan/gstack (1 total) - keep all


### PR DESCRIPTION
## Summary
- emilkowalski/skill (https://github.com/emilkowalski/skill) was already listed in SKILLS.txt with no skill selection (installs all), but the comment said "(1 total)"
- Repo actually has 8 skills: animation-vocabulary, apple-design, emil-design-eng, find-animation-opportunities, improve-animations, pick-ui-library, prototype, review-animations
- Updated the comment to "(8 total)" to match; no functional change since all skills were already being installed

## Test plan
- [x] Verified repo contents via `gh api repos/emilkowalski/skill/contents/skills`
- [x] Confirmed no skill-name selection needed (repo has <10 skills per SKILLS.txt convention)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the skill count comment for `emilkowalski/skill` in SKILLS.txt from (1 total) to (8 total) to match the repository. No functional change—still installs all skills.

<sup>Written for commit a989e18beca75c8e33048ff67f477dc34939c6d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

