### PR TITLE
feat(skills): add petergyang/no-ai-slop

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -115,6 +115,9 @@ nextlevelbuilder/ui-ux-pro-max-skill ui-ux-pro-max
 # paperclipai/paperclip (4 total) - keep core
 paperclipai/paperclip paperclip,paperclip-create-agent,paperclip-create-plugin
 
+# petergyang/no-ai-slop (1 total) - keep all
+petergyang/no-ai-slop
+
 # redwoodjs/agent-ci (1 total) - keep all
 redwoodjs/agent-ci agent-ci
 


### PR DESCRIPTION
## Summary
- Add `petergyang/no-ai-slop` to SKILLS.txt (1 skill: `no-ai-slop` - edits drafts into sharper, more human writing or detects AI-slop patterns)

## Test plan
- [x] Confirmed repo has 1 skill via `bunx skills add petergyang/no-ai-slop --global --list`
- [x] Matches existing SKILLS.txt format for single-skill repos

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `petergyang/no-ai-slop` to SKILLS.txt, registering the `no-ai-slop` skill. This makes the repo’s single skill available in the global skills list.

<sup>Written for commit 24aa990c5fc9ed11ed5021cdc917fc5027625c9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

