### PR TITLE
feat(mcp): add Paybox MCP server

### DIFF
--- a/.ruler/mcp.json
+++ b/.ruler/mcp.json
@@ -21,6 +21,10 @@
       "command": "python3-mempalace",
       "args": ["-m", "mempalace.mcp_server"]
     },
+    "Paybox": {
+      "type": "http",
+      "url": "https://api.paybox.sh/mcp"
+    },
     "Sentry": {
       "type": "http",
       "url": "https://mcp.sentry.dev/mcp"


### PR DESCRIPTION
Adds [Paybox](https://paybox.sh/) to `.ruler/mcp.json`, connecting `https://api.paybox.sh/mcp`.

## Changes

```json
"Paybox": {
  "type": "http",
  "url": "https://api.paybox.sh/mcp"
}
```

Entry is placed alphabetically between `MemPalace` and `Sentry`. No other files need changing — `make mcp-sync` copies `.ruler/mcp.json` to `~/.cursor`, `~/.claude`, and `~/.codex`, and derives `enabledMcpjsonServers` from its keys, so Paybox is picked up automatically on the next `make sync`.

## Why native HTTP instead of `mcp-remote`

Probed the endpoint directly. It's a spec-compliant streamable-HTTP MCP server with full OAuth 2.1 discovery, so it needs no proxy — same treatment as Sentry in #170:

- `POST /mcp` → `401` with `WWW-Authenticate: Bearer realm="paybox", resource_metadata="https://api.paybox.sh/.well-known/oauth-protected-resource"`
- Protected-resource metadata advertises `scopes_supported: ["mcp"]` and `bearer_methods_supported: ["header"]`
- Authorization-server metadata advertises PKCE (`S256`), `authorization_code` + `refresh_token` grants, and a dynamic client registration endpoint (`/oauth/register`)

That means the client can register and complete the OAuth flow on its own without a localhost callback listener from `mcp-remote`.

## Testing

- `jq` validates the file and confirms the key ordering
- OAuth discovery endpoints verified live (responses above)
- Interactive OAuth consent hasn't been run — that requires a browser sign-in on first use, so the connection is unauthenticated until someone approves it locally

---
_Generated by [Claude Code](https://claude.ai/code/session_01MK8pd7n8mNbSpdRmgoCdpR)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Paybox MCP server to `/.ruler/mcp.json` using native HTTP at https://api.paybox.sh/mcp. Paybox is available after the next `make mcp-sync`, with no `mcp-remote` proxy needed.

- **New Features**
  - Added `Paybox` entry with `type: "http"` and URL `https://api.paybox.sh/mcp`.
  - Auto-picked up by `make mcp-sync` and included in `enabledMcpjsonServers`; OAuth 2.1 with PKCE and dynamic client registration is supported by the server.

<sup>Written for commit 3320fb529b1902f39d7e5e97ec477673c39c1d11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

