### PR TITLE
feat(skills): add skills-update, drive install from SKILLS.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,10 @@ ruler-rules-copy: ## Copy rules to .ruler directory.
 # External skills are declared in SKILLS.txt and locked in skills-lock.json.
 
 .PHONY: skills-install
-skills-install: ## Install external skills from skills-lock.json (skips already installed).
+skills-install: ## Install external skills declared in SKILLS.txt (skips already installed).
+	@if [ -f "$(SKILLS_GLOBAL_LOCK)" ]; then \
+		$(MAKE) skills-lock; \
+	fi
 	@lock="$(SKILLS_LOCK_FILE)"; \
 	skills_dir="$(SKILLS_EXTERNAL_SOURCE_DIR)"; \
 	force="$${DOTAGENTS_FORCE_SKILLS_INSTALL:-0}"; \
@@ -120,11 +123,19 @@ skills-install: ## Install external skills from skills-lock.json (skips already 
 		fi; \
 	done; \
 	rm -f "$$tmp_missing"; \
+	if [ -f "$(SKILLS_GLOBAL_LOCK)" ]; then \
+		$(MAKE) skills-lock; \
+	fi; \
 	exit $$failed
 
 .PHONY: skills-refresh
 skills-refresh: ## Force a reinstall of all external skills from skills-lock.json.
 	@DOTAGENTS_FORCE_SKILLS_INSTALL=1 $(MAKE) skills-install
+
+.PHONY: skills-update
+skills-update: ## Update installed external skills to latest and refresh the lock.
+	@bun x skills update --global --yes </dev/null
+	@$(MAKE) skills-lock
 
 .PHONY: skills-lock
 skills-lock: ## Regenerate skills-lock.json from SKILLS.txt.

--- a/README.md
+++ b/README.md
@@ -14,16 +14,20 @@ This runs the full pipeline: prepares `.ruler/`, generates agent instruction fil
 External skills are declared in `SKILLS.txt` (canonical: repo plus comma-separated selection, no selection installs all) and locked in `skills-lock.json`, both committed. Installs go through the [skills CLI](https://github.com/vercel-labs/skills); global scope is scripted here because the CLI's own lock restore is project-only (see [vercel-labs/skills#549](https://github.com/vercel-labs/skills/issues/549)).
 
 ```bash
-# Regenerate skills-lock.json from SKILLS.txt
-make skills-lock
-
-# Install everything in the lock that is missing (idempotent)
+# Install everything declared in SKILLS.txt that is missing (idempotent;
+# regenerates skills-lock.json automatically)
 make skills-install
+
+# Update installed skills to latest and refresh the lock
+make skills-update
+
+# Regenerate skills-lock.json from SKILLS.txt without installing
+make skills-lock
 
 # Force a reinstall of everything in the lock
 make skills-refresh
 ```
 
-To add skills: edit `SKILLS.txt`, run `make skills-lock && make skills-install && make skills-lock` (the second lock captures resolved metadata), and commit both files. To remove: delete from `SKILLS.txt`, run `bunx skills remove <name> --global --yes`, then `make skills-lock`.
+To add skills: edit `SKILLS.txt`, run `make skills-install`, and commit both files. To remove: delete from `SKILLS.txt`, run `bunx skills remove <name> --global --yes`, then `make skills-lock`.
 
 Installs track each source's default branch: the skills CLI does not record commit SHAs in its lock yet, so entries are not pinned to a commit.

--- a/rules/skills-management.md
+++ b/rules/skills-management.md
@@ -23,8 +23,8 @@ bunx skills add owner/repo --global --list
 # Repos with <10 skills: install all (no selection)
 # Repos with 10+ skills: always specify selections
 
-# 3. Regenerate the lock, install, then re-lock to capture resolved metadata
-cd dotagents && make skills-lock && make skills-install && make skills-lock
+# 3. Install (regenerates skills-lock.json from SKILLS.txt automatically)
+cd dotagents && make skills-install
 
 # 4. Commit SKILLS.txt and skills-lock.json together
 ```
@@ -36,6 +36,15 @@ cd dotagents && make skills-lock && make skills-install && make skills-lock
 bunx skills remove <name> --global --yes
 cd dotagents && make skills-lock
 ```
+
+## Updating Installed Skills
+
+```bash
+cd dotagents && make skills-update
+```
+
+Runs `bun x skills update --global` and refreshes `skills-lock.json`; commit
+the resulting diff.
 
 ## Restoring (fresh machine or CI)
 


### PR DESCRIPTION
## What

- `make skills-install` now regenerates `skills-lock.json` from `SKILLS.txt` before installing (when the global CLI lock exists) and re-locks after installing, so adding a skill is: edit `SKILLS.txt` -> `make skills-install` -> commit both files. SKILLS.txt is the single source of truth; the lock is a derived artifact.
- New `make skills-update`: runs `bun x skills update --global --yes` then refreshes the lock.
- Docs updated (README, rules/skills-management.md).

Fresh machines are unaffected: with no global CLI lock present, `skills-install` skips regeneration and restores straight from the committed lock (and re-locks at the end once the CLI has created the global lock).

## Testing

Removed a skill via the CLI, edited nothing, ran a single `make skills-install`: the pre-install lock regen flagged it (555 skills, 1 not yet installed), reinstalled it, and the post-install re-lock resolved its `skillFolderHash`. Exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made `SKILLS.txt` the source of truth for external skills installs and added `make skills-update` to refresh installed skills and the lock. This streamlines add/update workflows while keeping fresh machine restores unchanged.

- **New Features**
  - `skills-install` installs from `SKILLS.txt` and auto-regenerates `skills-lock.json` before/after when `SKILLS_GLOBAL_LOCK` exists; skips regen on fresh machines.
  - `skills-update` runs `bun x skills update --global --yes` and then refreshes the lock.

- **Migration**
  - Add: edit `SKILLS.txt`, run `make skills-install`, commit `SKILLS.txt` and `skills-lock.json`.
  - Remove: delete from `SKILLS.txt`, run `bunx skills remove <name> --global --yes`, then `make skills-lock`.
  - Restore (fresh machines/CI): run `make skills-install` to install from the committed lock.

<sup>Written for commit 924dd6b3c188098abc82df5f4949da5adc4fc862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

