### PR TITLE
fix(skills): propagate re-lock failure, document prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ skills-install: ## Install external skills declared in SKILLS.txt (skips already
 	done; \
 	rm -f "$$tmp_missing"; \
 	if [ -f "$(SKILLS_GLOBAL_LOCK)" ]; then \
-		$(MAKE) skills-lock; \
+		$(MAKE) skills-lock || failed=1; \
 	fi; \
 	exit $$failed
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ make skills-install
 make skills-update
 
 # Regenerate skills-lock.json from SKILLS.txt without installing
+# (requires ~/.agents/.skill-lock.json, created by the first global install)
 make skills-lock
 
 # Force a reinstall of everything in the lock
 make skills-refresh
 ```
 
-To add skills: edit `SKILLS.txt`, run `make skills-install`, and commit both files. To remove: delete from `SKILLS.txt`, run `bunx skills remove <name> --global --yes`, then `make skills-lock`.
+To add skills: edit `SKILLS.txt`, run `make skills-install`, and commit both files. Install-all repos (no selection) need a one-time bootstrap before they appear in the lock: `bunx skills add owner/repo --global --yes --skill '*'` (the `make skills-lock` warning prints the exact command), then `make skills-lock`. To remove: delete from `SKILLS.txt`, run `bunx skills remove <name> --global --yes`, then `make skills-lock`.
 
 Installs track each source's default branch: the skills CLI does not record commit SHAs in its lock yet, so entries are not pinned to a commit.

--- a/rules/skills-management.md
+++ b/rules/skills-management.md
@@ -26,6 +26,9 @@ bunx skills add owner/repo --global --list
 # 3. Install (regenerates skills-lock.json from SKILLS.txt automatically)
 cd dotagents && make skills-install
 
+# Install-all repos (no selection) need a one-time bootstrap to enter the lock:
+# bunx skills add owner/repo --global --yes --skill '*'
+
 # 4. Commit SKILLS.txt and skills-lock.json together
 ```
 


### PR DESCRIPTION
Follow-ups from #176 review:

- skills-install now sets failed=1 when the post-install skills-lock regeneration fails, instead of exiting 0 with a stale lock
- README notes that make skills-lock requires the global CLI lock (created by the first global install)
- README + rules document the one-time bootstrap for install-all repos (bunx skills add owner/repo --global --yes --skill '*')

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates skills-lock regeneration failures from skills-install to prevent stale locks. Adds docs for the required global lock and a one-time bootstrap for install-all repos.

- **Bug Fixes**
  - `make skills-install` now exits non-zero if the post-install `make skills-lock` step fails (sets `failed=1`), avoiding stale locks.

- **Migration**
  - `make skills-lock` requires the global CLI lock at `~/.agents/.skill-lock.json` (created by the first global install).
  - For install-all repos (no selection), run once: `bunx skills add owner/repo --global --yes --skill '*'` before locking.

<sup>Written for commit f7d26e855b97052f738403219e09989ef60a9ec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

