### PR TITLE
fix(skills): remove stale upstream lock entries

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -34,8 +34,8 @@ cloudflare/skills agents-sdk,cloudflare,cloudflare-email-service,cloudflare-one,
 # coinbase/agentic-wallet-skills (1 total) - keep all
 coinbase/agentic-wallet-skills agentic-wallet
 
-# coreyhaines31/marketingskills (34 total) - keep analytics only
-coreyhaines31/marketingskills analytics-tracking
+# coreyhaines31/marketingskills (49 total) - keep analytics only
+coreyhaines31/marketingskills analytics
 
 # cursor/plugins (75 total) - keep cursor-team-kit + cursor SDK/plugin + pstack skills (excl. poteto-mode, benny automations)
 cursor/plugins check-compiler-errors,control-cli,control-ui,deslop,fix-ci,fix-merge-conflicts,get-pr-comments,loop-on-ci,make-pr-easy-to-review,new-branch-and-pr,pr-review-canvas,review-and-ship,run-smoke-tests,thermo-nuclear-code-quality-review,verify-this,weekly-review,what-did-i-get-done,workflow-from-chats,cli-for-agents,continual-learning,create-plugin-scaffold,review-plugin-submission,cursor-sdk,docs-canvas,orchestrate,architect,arena,automate-me,blast-radius,create-verification-skill,figure-it-out,how,interrogate,maintain-verification-skill,recall,reflect,setup-pstack,show-me-your-work,tdd,teach,typescript-best-practices,unslop,why,principle-boundary-discipline,principle-build-the-lever,principle-encode-lessons-in-structure,principle-exhaust-the-design-space,principle-experience-first,principle-fix-root-causes,principle-foundational-thinking,principle-guard-the-context-window,principle-laziness-protocol,principle-make-operations-idempotent,principle-migrate-callers-then-delete-legacy-apis,principle-minimize-reader-load,principle-model-the-domain,principle-never-block-on-the-human,principle-outcome-oriented-execution,principle-prove-it-works,principle-redesign-from-first-principles,principle-separate-before-serializing-shared-state,principle-sequence-verifiable-units,principle-subtract-before-you-add,principle-type-system-discipline
@@ -72,9 +72,6 @@ google/skills agent-platform-alert-configuration,agent-platform-deploy,agent-pla
 
 # googleworkspace/cli (93 total) - keep core gmail/calendar/drive
 googleworkspace/cli gws-calendar,gws-calendar-agenda,gws-calendar-insert,gws-docs,gws-docs-write,gws-drive,gws-drive-upload,gws-gmail,gws-gmail-read,gws-gmail-send,gws-sheets,gws-sheets-read,gws-tasks
-
-# Graphify-Labs/graphify (1 total) - keep all
-Graphify-Labs/graphify
 
 # higgsfield-ai/skills (5 total) - keep all
 higgsfield-ai/skills higgsfield-generate,higgsfield-marketplace-cards,higgsfield-product-photoshoot,higgsfield-soul-id,higgsfield-websites
@@ -192,12 +189,6 @@ vercel-labs/agent-browser agent-browser
 
 # vercel-labs/agent-skills (6 total) - keep core
 vercel-labs/agent-skills vercel-composition-patterns,deploy-to-vercel,vercel-react-best-practices,vercel-cli-with-tokens
-
-# vercel-labs/next-browser - keep all (install-all; upstream currently has no SKILL.md)
-vercel-labs/next-browser
-
-# vercel-labs/next-skills - keep all (install-all; upstream currently has no SKILL.md)
-vercel-labs/next-skills
 
 # vercel-labs/portless (2 total) - keep all
 vercel-labs/portless oauth,portless

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -232,12 +232,12 @@
       "skillPath": "skills/cloud/alloydb-basics/SKILL.md",
       "skillFolderHash": "1ce7947392394106cd2272802061c2c39f2d96e9"
     },
-    "analytics-tracking": {
+    "analytics": {
       "source": "coreyhaines31/marketingskills",
       "sourceType": "github",
       "sourceUrl": "https://github.com/coreyhaines31/marketingskills.git",
-      "skillPath": "skills/analytics-tracking/SKILL.md",
-      "skillFolderHash": "d6d50fd2bd4440bb0f075b4f2818a70667991f8b"
+      "skillPath": "skills/analytics/SKILL.md",
+      "skillFolderHash": "cbb8b810847072efe55e8de9c0dd42ddbcc5f91e"
     },
     "analyze": {
       "source": "anthropics/knowledge-work-plugins",
@@ -1758,13 +1758,6 @@
       "skillPath": "skills/cloud/google-cloud-waf-sustainability/SKILL.md",
       "skillFolderHash": "fd7ed477c4f5acb4ca98910b85cf90dc3ffa31f0"
     },
-    "graphify": {
-      "source": "Graphify-Labs/graphify",
-      "sourceType": "github",
-      "sourceUrl": "https://github.com/Graphify-Labs/graphify.git",
-      "skillPath": "graphify/SKILL.md",
-      "skillFolderHash": "a65104d74d49ef0ea34a98c4dea74da6cba038c8"
-    },
     "grill-me": {
       "source": "mattpocock/skills",
       "sourceType": "github",
@@ -2324,34 +2317,6 @@
       "sourceUrl": "https://github.com/elvisun/newsjack.git",
       "skillPath": "skills/newsworthiness-check/SKILL.md",
       "skillFolderHash": "1b385139b4d17d258414b1024a9438cccb70775f"
-    },
-    "next-best-practices": {
-      "source": "vercel-labs/next-skills",
-      "sourceType": "github",
-      "sourceUrl": "https://github.com/vercel-labs/next-skills.git",
-      "skillPath": "skills/next-best-practices/SKILL.md",
-      "skillFolderHash": "ad17eb27952b39a6ab0061bd50e8a2213b63a3ec"
-    },
-    "next-browser": {
-      "source": "vercel-labs/next-browser",
-      "sourceType": "github",
-      "sourceUrl": "https://github.com/vercel-labs/next-browser.git",
-      "skillPath": "skills/next-browser/SKILL.md",
-      "skillFolderHash": "9d8c0b32cbc8c81f085feb0eb73b50650fe9cef3"
-    },
-    "next-cache-components": {
-      "source": "vercel-labs/next-skills",
-      "sourceType": "github",
-      "sourceUrl": "https://github.com/vercel-labs/next-skills.git",
-      "skillPath": "skills/next-cache-components/SKILL.md",
-      "skillFolderHash": "a6f29564b9228af553737bd437c7016fc3dc44e0"
-    },
-    "next-upgrade": {
-      "source": "vercel-labs/next-skills",
-      "sourceType": "github",
-      "sourceUrl": "https://github.com/vercel-labs/next-skills.git",
-      "skillPath": "skills/next-upgrade/SKILL.md",
-      "skillFolderHash": "962598faa417cf3b6c03ec2e5cbe0aa0aeb2c4a9"
     },
     "no-ai-slop": {
       "source": "petergyang/no-ai-slop",


### PR DESCRIPTION
The skills lock contained five upstream entries that cannot be installed:

- `analytics-tracking` was renamed to `analytics`
- Graphify has no valid SKILL.md
- next-browser has invalid skill frontmatter
- next-skills has no valid skills

Update SKILLS.txt and skills-lock.json so `skills-install` only processes valid current sources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up SKILLS.txt and skills-lock.json to remove invalid upstreams and rename `analytics-tracking` to `analytics`. This makes `skills-install` only process valid sources and prevents install errors.

- **Bug Fixes**
  - Renamed `coreyhaines31/marketingskills` `analytics-tracking` to `analytics`.
  - Removed `Graphify-Labs/graphify` (no valid SKILL.md).
  - Removed `vercel-labs/next-browser` (invalid skill frontmatter).
  - Removed `vercel-labs/next-skills` entries (no valid skills).

<sup>Written for commit 8a6c23679ea82430a85d463728032f185654501b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

