### PR TITLE
feat(skills): add new Matt Pocock skills

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -118,8 +118,8 @@ openclaw/agent-skills autoreview
 # PaulRBerg/agent-skills (23 total) - keep dev tools
 PaulRBerg/agent-skills bump-deps,bump-release,cli-gh,code-polish,effect-ts,tailwind-css,yeet
 
-# mattpocock/skills (38 total) - keep all
-mattpocock/skills ask-matt,claude-handoff,code-review,codebase-design,design-an-interface,diagnosing-bugs,domain-modeling,edit-article,git-guardrails-claude-code,grill-me,grill-with-docs,grilling,handoff,implement,improve-codebase-architecture,loop-me,migrate-to-shoehorn,obsidian-vault,prototype,qa,request-refactor-plan,research,resolving-merge-conflicts,scaffold-exercises,setup-matt-pocock-skills,setup-pre-commit,tdd,teach,to-tickets,to-spec,triage,ubiquitous-language,wayfinder,wizard,writing-beats,writing-fragments,writing-great-skills,writing-shape
+# mattpocock/skills (41 total) - keep all
+mattpocock/skills ask-matt,batch-grill-me,claude-handoff,code-review,codebase-design,design-an-interface,diagnosing-bugs,domain-modeling,edit-article,git-guardrails-claude-code,grill-me,grill-with-docs,grilling,handoff,implement,improve-codebase-architecture,loop-me,migrate-to-shoehorn,obsidian-vault,prototype,qa,request-refactor-plan,research,resolving-merge-conflicts,scaffold-exercises,setup-matt-pocock-skills,setup-pre-commit,setup-ts-deep-modules,tdd,teach,to-questionnaire,to-tickets,to-spec,triage,ubiquitous-language,wayfinder,wizard,writing-beats,writing-fragments,writing-great-skills,writing-shape
 
 # max-sixty/worktrunk (2 total) - keep all
 max-sixty/worktrunk worktrunk,wt-switch-create

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -358,6 +358,13 @@
       "skillPath": ".agents/skills/axi/SKILL.md",
       "skillFolderHash": "9a238ca5757ff4d7931adafb8d3747c93d0f8eb6"
     },
+    "batch-grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/mattpocock/skills.git",
+      "skillPath": "skills/in-progress/batch-grill-me/SKILL.md",
+      "skillFolderHash": "f2c0125db05db4d8f905a9423af308c476e2e4d5"
+    },
     "bd-to-br-migration": {
       "source": "shunkakinoki/private-skills",
       "sourceType": "github",
@@ -3088,6 +3095,13 @@
       "skillPath": "pstack/skills/setup-pstack/SKILL.md",
       "skillFolderHash": "8fd669f0bab6c8807e06696d80220943f8c16226"
     },
+    "setup-ts-deep-modules": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/mattpocock/skills.git",
+      "skillPath": "skills/in-progress/setup-ts-deep-modules/SKILL.md",
+      "skillFolderHash": "706cd1617d53587b0c4e6df5a8c56974f54cacd2"
+    },
     "shipping-and-launch": {
       "source": "addyosmani/agent-skills",
       "sourceType": "github",
@@ -3388,6 +3402,13 @@
       "sourceUrl": "https://github.com/anthropics/defending-code-reference-harness.git",
       "skillPath": ".claude/skills/threat-model/SKILL.md",
       "skillFolderHash": "e32a9e833f45a3e6e24330ee11bf7ab74c87182a"
+    },
+    "to-questionnaire": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/mattpocock/skills.git",
+      "skillPath": "skills/in-progress/to-questionnaire/SKILL.md",
+      "skillFolderHash": "7c4d04fb4d77824d7d98433ee7a8b17dde5efa13"
     },
     "to-spec": {
       "source": "mattpocock/skills",


### PR DESCRIPTION
## Summary

- add the three new skills currently published by mattpocock/skills: `batch-grill-me`, `setup-ts-deep-modules`, and `to-questionnaire`
- update `SKILLS.txt` from 38 to 41 declared skills
- regenerate `skills-lock.json` with upstream paths and hashes

## Validation

- `jq` schema and lock-entry checks pass
- 41-entry declaration check passes
- `git diff --check` passes
- `bun run prepare` / Ruler generation passes
- Biome check is blocked in this macOS ARM checkout because Bun did not install the optional `@biomejs/cli-darwin-arm64` binary from the committed dependency lock

Source: https://www.aihero.dev/skills-writing-great-skills

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added three new `mattpocock/skills`: `batch-grill-me`, `setup-ts-deep-modules`, and `to-questionnaire`, and regenerated `skills-lock.json` with upstream paths and hashes. Updated `SKILLS.txt` to list 41 skills for `mattpocock/skills`.

<sup>Written for commit 1a76481db7c079bc28765e48d3090f718c5f3bca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

