### PR TITLE
fix(skills): stop rewriting lock on every install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,7 @@ ruler-rules-copy: ## Copy rules to .ruler directory.
 # External skills are declared in SKILLS.txt and locked in skills-lock.json.
 
 .PHONY: skills-install
-skills-install: ## Install external skills declared in SKILLS.txt (skips already installed).
-	@if [ -f "$(SKILLS_GLOBAL_LOCK)" ]; then \
-		$(MAKE) skills-lock; \
-	fi
+skills-install: ## Install external skills from skills-lock.json (skips already installed; does not rewrite the lock).
 	@lock="$(SKILLS_LOCK_FILE)"; \
 	skills_dir="$(SKILLS_EXTERNAL_SOURCE_DIR)"; \
 	force="$${DOTAGENTS_FORCE_SKILLS_INSTALL:-0}"; \
@@ -123,7 +120,7 @@ skills-install: ## Install external skills declared in SKILLS.txt (skips already
 		fi; \
 	done; \
 	rm -f "$$tmp_missing"; \
-	if [ -f "$(SKILLS_GLOBAL_LOCK)" ]; then \
+	if [ "$$failed" = "0" ] && [ -f "$(SKILLS_GLOBAL_LOCK)" ]; then \
 		$(MAKE) skills-lock || failed=1; \
 	fi; \
 	exit $$failed

--- a/rules/skills-management.md
+++ b/rules/skills-management.md
@@ -23,13 +23,17 @@ bunx skills add owner/repo --global --list
 # Repos with <10 skills: install all (no selection)
 # Repos with 10+ skills: always specify selections
 
-# 3. Install (regenerates skills-lock.json from SKILLS.txt automatically)
+# 3. Bootstrap into the global lock, then regenerate the committed lock
+bunx skills add owner/repo --global --yes --skill name
+# Install-all repos (no selection):
+# bunx skills add owner/repo --global --yes --skill '*'
+cd dotagents && make skills-lock
+
+# 4. Install any still-missing skills from the lock (does not rewrite the lock
+#    when everything is already installed; make sync relies on that)
 cd dotagents && make skills-install
 
-# Install-all repos (no selection) need a one-time bootstrap to enter the lock:
-# bunx skills add owner/repo --global --yes --skill '*'
-
-# 4. Commit SKILLS.txt and skills-lock.json together
+# 5. Commit SKILLS.txt and skills-lock.json together
 ```
 
 ## Removing Skills


### PR DESCRIPTION
## Summary
- Stop `skills-install` from regenerating `skills-lock.json` when every skill is already installed
- Only refresh the lock after a successful install of missing skills
- Update skills-management docs for the bootstrap → lock → install flow

## Test plan
- [x] `make skills-install` with all skills present leaves `skills-lock.json` clean
- [ ] `make sync` does not dirty the `dotagents` submodule
- [ ] Adding a new skill still works via `make skills-lock` then `make skills-install`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `skills-install` from rewriting `skills-lock.json` when no installs are needed. Keeps the `dotagents` submodule clean and unblocks `make sync`/`make reset`.

- **Bug Fixes**
  - `skills-install` no longer runs `skills-lock` up front; it refreshes the lock only after a successful install of missing skills and when a global lock exists.
  - Updated `rules/skills-management.md` to use: bootstrap into the global lock (`bunx skills add owner/repo --global --yes --skill ...`) → `make skills-lock` → `make skills-install` (which now skips lock rewrites when everything is installed).

<sup>Written for commit fe20a8b2af6a48f575528152451f417f6225a0dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

