### PR TITLE
feat(skills): add DietrichGebert/ponytail

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -43,6 +43,9 @@ cursor/plugins check-compiler-errors,control-cli,control-ui,deslop,fix-ci,fix-me
 # Dicklesworthstone/coding_agent_session_search (1 total) - keep all
 Dicklesworthstone/coding_agent_session_search cass
 
+# DietrichGebert/ponytail (6 total) - keep all
+DietrichGebert/ponytail ponytail,ponytail-audit,ponytail-debt,ponytail-gain,ponytail-help,ponytail-review
+
 # donnfelker/donnfelker-plugin-marketplace (3 total) - keep all
 donnfelker/donnfelker-plugin-marketplace codebase-analyzer,find-past-conversation,generate-release-notes
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -2528,6 +2528,48 @@
       "skillPath": "skills/pnpm/SKILL.md",
       "skillFolderHash": "4be8fd8b101fbcba93f2fbc432802034b294c790"
     },
+    "ponytail": {
+      "source": "DietrichGebert/ponytail",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/DietrichGebert/ponytail.git",
+      "skillPath": "skills/ponytail/SKILL.md",
+      "skillFolderHash": "cb6e53477eaf04e6daeca22feacb85f9ce20d40c"
+    },
+    "ponytail-audit": {
+      "source": "DietrichGebert/ponytail",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/DietrichGebert/ponytail.git",
+      "skillPath": "skills/ponytail-audit/SKILL.md",
+      "skillFolderHash": "19744a9490abb0f5d0f18c6e39e3a3eb50f4daa1"
+    },
+    "ponytail-debt": {
+      "source": "DietrichGebert/ponytail",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/DietrichGebert/ponytail.git",
+      "skillPath": "skills/ponytail-debt/SKILL.md",
+      "skillFolderHash": "fe9ea82cad2b42a9c244acc275c9091c414ff528"
+    },
+    "ponytail-gain": {
+      "source": "DietrichGebert/ponytail",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/DietrichGebert/ponytail.git",
+      "skillPath": "skills/ponytail-gain/SKILL.md",
+      "skillFolderHash": "13724e1903f76456164f00ec2a3074848433588f"
+    },
+    "ponytail-help": {
+      "source": "DietrichGebert/ponytail",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/DietrichGebert/ponytail.git",
+      "skillPath": "skills/ponytail-help/SKILL.md",
+      "skillFolderHash": "b7df7bc32b6e4e8bbde8acb2ef3c97ee7e7638f7"
+    },
+    "ponytail-review": {
+      "source": "DietrichGebert/ponytail",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/DietrichGebert/ponytail.git",
+      "skillPath": "skills/ponytail-review/SKILL.md",
+      "skillFolderHash": "dc6d9660c4297496a9220de377f6f7df38ab1a53"
+    },
     "portless": {
       "source": "vercel-labs/portless",
       "sourceType": "github",


### PR DESCRIPTION
## Summary
- Add all 6 skills from [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail): `ponytail`, `ponytail-audit`, `ponytail-debt`, `ponytail-gain`, `ponytail-help`, `ponytail-review`
- Regenerate `skills-lock.json` entries for the new repo

## Test plan
- [x] `npx skills add DietrichGebert/ponytail --global --list` confirmed 6 skills, all under the <10 "keep all" threshold
- [x] `make sync` installed the skills to `~/.agents/skills` and `~/.claude/skills`
- [x] Verified `skills-lock.json` diff is scoped to the new repo only (unrelated repo noise from transient network failures during regen was reverted)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add all six skills from `DietrichGebert/ponytail` and regenerate `skills-lock.json` entries. Adds `ponytail`, `ponytail-audit`, `ponytail-debt`, `ponytail-gain`, `ponytail-help`, and `ponytail-review`; updates SKILLS.txt accordingly.

<sup>Written for commit 286ee731afabb55263643b7c588a340e929e0458. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

