### PR TITLE
feat(skills): add taste-skill frontend design skills

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -100,8 +100,8 @@ kunchenguid/axi axi
 # kunchenguid/no-mistakes (1 total) - keep all
 kunchenguid/no-mistakes
 
-# Leonxlnx/taste-skill (8 total) - keep frontend design skills, skip gpt/stitch/brutalist
-Leonxlnx/taste-skill design-taste-frontend,high-end-visual-design,minimalist-ui,redesign-existing-projects,full-output-enforcement
+# Leonxlnx/taste-skill (13 total) - keep frontend design skills, skip gpt/stitch/brutalist/brandkit and the v1 duplicate
+Leonxlnx/taste-skill design-taste-frontend,high-end-visual-design,minimalist-ui,redesign-existing-projects,full-output-enforcement,image-to-code,imagegen-frontend-web,imagegen-frontend-mobile
 
 # obra/superpowers (14 total) - keep dev workflow
 obra/superpowers dispatching-parallel-agents,executing-plans,finishing-a-development-branch,receiving-code-review,requesting-code-review,systematic-debugging,test-driven-development,using-git-worktrees,verification-before-completion,writing-plans,writing-skills

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1940,6 +1940,27 @@
       "skillPath": "skills/idea-wizard/SKILL.md",
       "skillFolderHash": "5c24deb041a0cece61c13623eecbf066a21ea7f6"
     },
+    "image-to-code": {
+      "source": "Leonxlnx/taste-skill",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/Leonxlnx/taste-skill.git",
+      "skillPath": "skills/image-to-code-skill/SKILL.md",
+      "skillFolderHash": "701b3cb89c061fcf98a98f639e0b0b5c0b492479"
+    },
+    "imagegen-frontend-mobile": {
+      "source": "Leonxlnx/taste-skill",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/Leonxlnx/taste-skill.git",
+      "skillPath": "skills/imagegen-frontend-mobile/SKILL.md",
+      "skillFolderHash": "9901fcde67e9506a706912107825fdfb72e01f30"
+    },
+    "imagegen-frontend-web": {
+      "source": "Leonxlnx/taste-skill",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/Leonxlnx/taste-skill.git",
+      "skillPath": "skills/imagegen-frontend-web/SKILL.md",
+      "skillFolderHash": "3b5117d349200e33f9c3399344681620079dcc18"
+    },
     "implement": {
       "source": "mattpocock/skills",
       "sourceType": "github",


### PR DESCRIPTION
Leonxlnx/taste-skill grew from 8 to 13 skills. This picks up the new ones that match the existing frontend-design filter.

## Added

- `image-to-code` - generates design images, then implements the site to match
- `imagegen-frontend-web` - per-section website design references
- `imagegen-frontend-mobile` - app-native mobile screen concepts

## Still excluded

- `gpt-taste`, `stitch-design-taste`, `industrial-brutalist-ui` - already excluded by the existing filter
- `brandkit` - brand identity boards, not frontend
- `design-taste-frontend-v1` - superseded by `design-taste-frontend`

Lock regenerated with `make skills-lock`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs frontend-design skills from `Leonxlnx/taste-skill` after the repo grew from 8 to 13 skills. Adds the new frontend skills and keeps non-frontend and duplicate entries excluded.

- **New Features**
  - `image-to-code` – generates design images, then implements the site to match
  - `imagegen-frontend-web` – per-section web design references
  - `imagegen-frontend-mobile` – mobile app screen concepts

- **Dependencies**
  - Updated SKILLS.txt filter and regenerated `skills-lock.json` with `make skills-lock`

<sup>Written for commit 49721889ddcbb0868b55a86e493de35964b63d93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

