### PR TITLE
feat(rules): add code comment placement rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ SKILLS_FILE := $(dir $(lastword $(MAKEFILE_LIST)))SKILLS.txt
 SKILLS_LOCK_FILE := $(dir $(lastword $(MAKEFILE_LIST)))skills-lock.json
 SKILLS_EXTERNAL_SOURCE_DIR := $(HOME)/.agents/skills
 SKILLS_GLOBAL_LOCK := $(HOME)/.agents/.skill-lock.json
-SKILLS_CLI := ./node_modules/.bin/skills
+SKILLS_PROJECT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+SKILLS_CLI := $(SKILLS_PROJECT_DIR)/node_modules/.bin/skills
 
 MCP_SRC := $(dir $(lastword $(MAKEFILE_LIST))).ruler/mcp.json
 MCP_TARGET_DIRS := $(HOME)/.cursor $(HOME)/.claude $(HOME)/.codex
@@ -88,7 +89,7 @@ skills-install: ## Install external skills from skills-lock.json (skips already 
 	@lock="$(SKILLS_LOCK_FILE)"; \
 	skills_dir="$(SKILLS_EXTERNAL_SOURCE_DIR)"; \
 	force="$${DOTAGENTS_FORCE_SKILLS_INSTALL:-0}"; \
-	if ! bun install --frozen-lockfile --minimum-release-age 0 --no-progress >/dev/null; then \
+	if ! (cd "$(SKILLS_PROJECT_DIR)" && bun install --frozen-lockfile --minimum-release-age 0 --no-progress >/dev/null); then \
 		echo "Error: failed to install the skills SDK from bun.lock"; \
 		exit 1; \
 	fi; \
@@ -136,7 +137,7 @@ skills-refresh: ## Force a reinstall of all external skills from skills-lock.jso
 
 .PHONY: skills-update
 skills-update: ## Update installed external skills to latest and refresh the lock.
-	@bun install --frozen-lockfile --minimum-release-age 0 --no-progress >/dev/null
+	@cd "$(SKILLS_PROJECT_DIR)" && bun install --frozen-lockfile --minimum-release-age 0 --no-progress >/dev/null
 	@$(SKILLS_CLI) update --global --yes </dev/null
 	@$(MAKE) skills-lock
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SKILLS_FILE := $(dir $(lastword $(MAKEFILE_LIST)))SKILLS.txt
 SKILLS_LOCK_FILE := $(dir $(lastword $(MAKEFILE_LIST)))skills-lock.json
 SKILLS_EXTERNAL_SOURCE_DIR := $(HOME)/.agents/skills
 SKILLS_GLOBAL_LOCK := $(HOME)/.agents/.skill-lock.json
+SKILLS_CLI := ./node_modules/.bin/skills
 
 MCP_SRC := $(dir $(lastword $(MAKEFILE_LIST))).ruler/mcp.json
 MCP_TARGET_DIRS := $(HOME)/.cursor $(HOME)/.claude $(HOME)/.codex
@@ -87,6 +88,10 @@ skills-install: ## Install external skills from skills-lock.json (skips already 
 	@lock="$(SKILLS_LOCK_FILE)"; \
 	skills_dir="$(SKILLS_EXTERNAL_SOURCE_DIR)"; \
 	force="$${DOTAGENTS_FORCE_SKILLS_INSTALL:-0}"; \
+	if ! bun install --frozen-lockfile --minimum-release-age 0 --no-progress >/dev/null; then \
+		echo "Error: failed to install the skills SDK from bun.lock"; \
+		exit 1; \
+	fi; \
 	if [ ! -f "$$lock" ]; then \
 		echo "Error: $$lock not found"; \
 		exit 1; \
@@ -109,7 +114,7 @@ skills-install: ## Install external skills from skills-lock.json (skips already 
 		skill_args=$$(printf '%s\n' "$$names" | while IFS= read -r n; do printf ' --skill %s' "$$n"; done); \
 		count=$$(printf '%s\n' "$$names" | wc -l | tr -d ' '); \
 		echo "Installing $$count skill(s) from $$source..."; \
-		bun x skills add "$$source" --global --yes $$skill_args </dev/null; \
+		$(SKILLS_CLI) add "$$source" --global --yes $$skill_args </dev/null; \
 		status=$$?; \
 		still_missing=$$(printf '%s\n' "$$names" | while IFS= read -r n; do \
 			if [ ! -e "$$skills_dir/$$n" ] && [ ! -L "$$skills_dir/$$n" ]; then printf ' %s' "$$n"; fi; \
@@ -131,7 +136,8 @@ skills-refresh: ## Force a reinstall of all external skills from skills-lock.jso
 
 .PHONY: skills-update
 skills-update: ## Update installed external skills to latest and refresh the lock.
-	@bun x skills update --global --yes </dev/null
+	@bun install --frozen-lockfile --minimum-release-age 0 --no-progress >/dev/null
+	@$(SKILLS_CLI) update --global --yes </dev/null
 	@$(MAKE) skills-lock
 
 .PHONY: skills-lock
@@ -139,7 +145,7 @@ skills-lock: ## Regenerate skills-lock.json from SKILLS.txt.
 	@global_lock="$(SKILLS_GLOBAL_LOCK)"; \
 	skills_dir="$(SKILLS_EXTERNAL_SOURCE_DIR)"; \
 	if [ ! -f "$$global_lock" ]; then \
-		echo "Error: $$global_lock not found; install a skill first (bun x skills add ... --global) to initialize it."; \
+		echo "Error: $$global_lock not found; install a skill first ($(SKILLS_CLI) add ... --global) to initialize it."; \
 		exit 1; \
 	fi; \
 	if ! jq -e '(.version | type == "number") and (.skills | type == "object")' "$$global_lock" >/dev/null; then \
@@ -151,7 +157,7 @@ skills-lock: ## Regenerate skills-lock.json from SKILLS.txt.
 	jq --argjson ondisk "$$ondisk" --argjson spec "$$spec" '. as $$lock | ($$lock.skills | with_entries(select(.key as $$k | $$ondisk | index($$k))) | with_entries(.value |= ({source, sourceType, sourceUrl, ref, skillPath, skillFolderHash} | with_entries(select(.value != null))))) as $$inst | reduce $$spec[] as $$s ({}; if ($$s.names | length) == 0 then . + ($$inst | with_entries(select(.value.source | ascii_downcase == ($$s.repo | ascii_downcase)))) else reduce $$s.names[] as $$n (.; ($$inst[$$n] // null) as $$hit | .[$$n] = (if $$hit != null and (($$hit.source | ascii_downcase) == ($$s.repo | ascii_downcase)) then $$hit elif .[$$n] != null then .[$$n] elif ($$s.repo | test("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$$")) then {source: $$s.repo, sourceType: "github", sourceUrl: "https://github.com/\($$s.repo).git"} else {source: $$s.repo} end)) end) | {version: $$lock.version, skills: (to_entries | sort_by(.key) | from_entries)}' "$$global_lock" > "$(SKILLS_LOCK_FILE).tmp" && mv "$(SKILLS_LOCK_FILE).tmp" "$(SKILLS_LOCK_FILE)"; \
 	for repo in $$(printf '%s' "$$spec" | jq -r '.[] | select(.names | length == 0) | .repo'); do \
 		if ! jq -e --arg repo "$$repo" '[.skills[] | select(.source | ascii_downcase == ($$repo | ascii_downcase))] | length > 0' "$(SKILLS_LOCK_FILE)" >/dev/null; then \
-			echo "warn: no installed skills for install-all repo $$repo; run: bun x skills add $$repo --global --yes --skill '*'"; \
+			echo "warn: no installed skills for install-all repo $$repo; run: bun install --frozen-lockfile --minimum-release-age 0 && $(SKILLS_CLI) add $$repo --global --yes --skill '*'"; \
 		fi; \
 	done; \
 	undeclared=$$(jq -r --argjson ondisk "$$ondisk" --slurpfile out "$(SKILLS_LOCK_FILE)" '.skills | keys[] | . as $$k | select(($$ondisk | index($$k)) and ($$out[0].skills | has($$k) | not))' "$$global_lock" | paste -sd, -); \

--- a/UPGRADE_LOG.md
+++ b/UPGRADE_LOG.md
@@ -5,4 +5,4 @@
 - `skills`: updated from `^1.5.20` to `^1.5.22`, the current stable release.
 - `bun.lock` records the resolved `skills@1.5.22` package and its new transitive dependencies.
 - The Makefile now invokes the project-local SDK binary and refreshes dependencies with Bun's release-age check disabled, so the declared current release is available immediately.
-- Verification: `./node_modules/.bin/skills --version`, `bun install --frozen-lockfile --minimum-release-age 0 --no-progress`, `make skills-install`, and `make sync`.
+- Verification: `./node_modules/.bin/skills --version`, frozen-lockfile install, `make skills-install` from both `dotagents/` and the upstream `~/dotfiles` checkout, and `make sync`.

--- a/UPGRADE_LOG.md
+++ b/UPGRADE_LOG.md
@@ -1,0 +1,8 @@
+# Dependency upgrade log
+
+## 2026-08-06
+
+- `skills`: updated from `^1.5.20` to `^1.5.22`, the current stable release.
+- `bun.lock` records the resolved `skills@1.5.22` package and its new transitive dependencies.
+- The Makefile now invokes the project-local SDK binary and refreshes dependencies with Bun's release-age check disabled, so the declared current release is available immediately.
+- Verification: `./node_modules/.bin/skills --version`, `bun install --frozen-lockfile --minimum-release-age 0 --no-progress`, `make skills-install`, and `make sync`.

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@biomejs/biome": "2.3.11",
         "@intellectronica/ruler": "^0.3.23",
         "lefthook": "^2.0.15",
-        "skills": "^1.5.20",
+        "skills": "^1.5.22",
       },
     },
   },
@@ -35,11 +35,15 @@
 
     "@intellectronica/ruler": ["@intellectronica/ruler@0.3.23", "", { "dependencies": { "@iarna/toml": "^2.2.5", "js-yaml": "^4.1.0", "yargs": "^18.0.0", "zod": "^4.1.12" }, "bin": { "ruler": "dist/cli/index.js" } }, "sha512-HjP4Dx0cAmpILoHJ0hJapuSUaxL3/VDXItU6NPg7kHLBFupUOVWU1wHELSiiin0bfq3hjQ318OypIl0C1v83Jg=="],
 
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
@@ -75,15 +79,23 @@
 
     "lefthook-windows-x64": ["lefthook-windows-x64@2.0.15", "", { "os": "win32", "cpu": "x64" }, "sha512-/zYEndCUgj8XK+4wvLYLRk3AcfKU6zWf2GHx+tcZ4K2bLaQdej4m+OqmQsVpUlF8N2tN9hfwlj1D50uz75LUuQ=="],
 
-    "skills": ["skills@1.5.20", "", { "dependencies": { "yaml": "^2.8.3" }, "bin": { "skills": "bin/cli.mjs", "add-skill": "bin/cli.mjs" } }, "sha512-lPl5KzMfTW+qwHFwc8t6R+wAqmdmSHw1+HWbGdJ/FZYbWLdB34bAZNFWiencM5DVoRaKAgXArmfTWMlNAbl9Gg=="],
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "skills": ["skills@1.5.22", "", { "dependencies": { "tar": "^7.5.20", "yaml": "^2.8.3" }, "bin": { "skills": "bin/cli.mjs", "add-skill": "bin/cli.mjs" } }, "sha512-cHiLjwZEawWFvudIqeeMZlvZayTLbRouydMbblyrdiyH7ZLbqUrSrEEr+Tg+X265iztRlVMsyOYRwpD5JxBsvg=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
+
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@biomejs/biome": "2.3.11",
     "@intellectronica/ruler": "^0.3.23",
     "lefthook": "^2.0.15",
-    "skills": "^1.5.20"
+    "skills": "^1.5.22"
   },
   "packageManager": "bun@1.2.22"
 }

--- a/rules/code-comments.md
+++ b/rules/code-comments.md
@@ -1,0 +1,8 @@
+# Code Comments
+
+- Write only non-obvious WHY: hidden constraints, why a workaround exists, surprising behavior.
+- No WHAT comments. `// get the user ID` is zero information.
+- No change history. That belongs in `git log` and the PR.
+- No task ID references. Put the needed context in the comment itself.
+- Never pad uncertain code with comments. Flag uncertainty in the PR body, not the source.
+- Docs and README: current behavior only, no rationale trails or migration history.


### PR DESCRIPTION
Adds a compact code-comments rule to `rules/`, propagated to all agent instruction files via ruler.

- Comments carry only non-obvious WHY (hidden constraints, workarounds, surprising behavior)
- No WHAT comments, change history, or task ID references - those belong in git log, the PR, or the issue
- Uncertainty goes in the PR body, not comment padding
- Docs/README: current behavior snapshot only

Based on the placement test: not "is this information useful?" but "is the code the right place for it?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a clear code comment rule: write only non‑obvious WHY; keep WHAT, history, and task IDs out of source. Also switches skills tasks to the project‑local CLI and bumps `skills` to `^1.5.22` for consistent installs.

- **New Features**
  - Added `rules/code-comments.md` with concise guidance; propagated via `@intellectronica/ruler`.

- **Dependencies**
  - Upgraded `skills` to `^1.5.22`; updated `bun.lock` (includes `tar` and related deps).
  - Makefile: use local `$(SKILLS_CLI)` instead of `bun x`; run `bun install --frozen-lockfile --minimum-release-age 0` before skills tasks.
  - Added `UPGRADE_LOG.md` with verification steps.

<sup>Written for commit f58796256b2e8044e6e6a84ccc4cdfc0980936ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

