### PR TITLE
feat(skills): add before-and-after

### DIFF
--- a/SKILLS.txt
+++ b/SKILLS.txt
@@ -187,6 +187,9 @@ vercel/turborepo turborepo
 # vercel-labs/agent-browser (5 total) - keep core
 vercel-labs/agent-browser agent-browser
 
+# vercel-labs/before-and-after (1 total) - keep all
+vercel-labs/before-and-after
+
 # vercel-labs/agent-skills (6 total) - keep core
 vercel-labs/agent-skills vercel-composition-patterns,deploy-to-vercel,vercel-react-best-practices,vercel-cli-with-tokens
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -393,6 +393,13 @@
       "skillPath": "skills/beads-workflow/SKILL.md",
       "skillFolderHash": "071c45a2e7e64b0f06d00e2abdd62531cc6ead70"
     },
+    "before-and-after": {
+      "source": "vercel-labs/before-and-after",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/vercel-labs/before-and-after.git",
+      "skillPath": "skill/SKILL.md",
+      "skillFolderHash": "494b495538546c3a5594285e726970ff8f27a1ee"
+    },
     "better-auth-best-practices": {
       "source": "better-auth/skills",
       "sourceType": "github",


### PR DESCRIPTION
Adds Vercels before-and-after screenshot skill to the managed catalog and lockfile.

Validated with make skills-install.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the `vercel-labs/before-and-after` screenshot skill to the managed catalog and updated `skills-lock.json` to lock its source for consistent installs.

<sup>Written for commit 9589ed3568017b7d7e422e783425c406946ef173. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotagents/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

